### PR TITLE
[draft] App alert remediation for api.handle.me (api.timeout). First determine which repo owns this alert from the incident context, logs, and repo search. Then create a GitHub issue in that repo and continue remediation. Triage summary: 1 incident(s) detected for api.handle.me.. Suggested action: Proceed with standard incident response flow.. Evidence: dispatch:discord-3. Initial alert message: timeout exceeded. Health probe detail: https://west.api.handle.me /stats HTTP 0: connection_failed:timeout exceeded

### DIFF
--- a/controllers/health.controller.test.ts
+++ b/controllers/health.controller.test.ts
@@ -74,6 +74,7 @@ describe('HealthController', () => {
                 })
             })
         );
+        expect(repoMock.isCaughtUp).toHaveBeenCalledWith(baseMetrics);
         expect(res.json.mock.calls[0][0].ogmios).toBeUndefined();
         expect(next).not.toHaveBeenCalled();
     });

--- a/controllers/health.controller.ts
+++ b/controllers/health.controller.ts
@@ -26,7 +26,8 @@ class HealthController {
     public async index (req: Request, res: Response, next: NextFunction): Promise<void> {
         try {
             const handleRepo = new HandlesRepository(new (req.app.get('registry') as IRegistry).handlesStore());
-            const { firstSlot = 0, lastSlot = 0, currentSlot = 0, firstMemoryUsage = 0, currentBlockHash = '', tipBlockHash = '', memorySize = 0, utxoSchemaVersion = 0, indexSchemaVersion = 0, handleCount = 0, holderCount = 0, startTimestamp = 0, lockLambdas } = handleRepo.getMetrics();
+            const metrics = handleRepo.getMetrics();
+            const { firstSlot = 0, lastSlot = 0, currentSlot = 0, firstMemoryUsage = 0, currentBlockHash = '', tipBlockHash = '', memorySize = 0, utxoSchemaVersion = 0, indexSchemaVersion = 0, handleCount = 0, holderCount = 0, startTimestamp = 0, lockLambdas } = metrics;
             const handleSlotRange = lastSlot - firstSlot;
             const currentSlotInRange = currentSlot - firstSlot;
             const transpiredMs = Date.now() - startTimestamp;
@@ -53,7 +54,7 @@ class HealthController {
             };
 
             let status = HealthStatus.CURRENT;
-            if (!handleRepo.isCaughtUp()) {
+            if (!handleRepo.isCaughtUp(metrics)) {
                 status = HealthStatus.STORAGE_BEHIND;
             }
             const ogmiosScanningEnabled = process.env.ENABLE_OGMIOS_SCANNING?.toLocaleLowerCase() !== 'false';

--- a/controllers/mcp.controller.ts
+++ b/controllers/mcp.controller.ts
@@ -178,7 +178,7 @@ class MCPController {
         if (name === 'get_stats') {
             const metrics = handleRepo.getMetrics();
             return {
-                status: handleRepo.currentHttpStatus(),
+                status: handleRepo.currentHttpStatus(metrics),
                 total_handles: metrics.handleCount ?? 0,
                 total_holders: metrics.holderCount ?? 0
             };

--- a/controllers/stats.controller.test.ts
+++ b/controllers/stats.controller.test.ts
@@ -43,6 +43,7 @@ describe('StatsController', () => {
             total_handles: 0,
             total_holders: 7
         });
+        expect(repoMock.currentHttpStatus).toHaveBeenCalledWith({ handleCount: undefined, holderCount: 7 });
         expect(next).not.toHaveBeenCalled();
     });
 
@@ -63,6 +64,7 @@ describe('StatsController', () => {
             total_handles: 5,
             total_holders: 0
         });
+        expect(repoMock.currentHttpStatus).toHaveBeenCalledWith({ handleCount: 5, holderCount: undefined });
     });
 
     it('forwards unexpected repository errors to next', async () => {

--- a/controllers/stats.controller.ts
+++ b/controllers/stats.controller.ts
@@ -11,7 +11,7 @@ class StatsController {
                 total_handles: metrics.handleCount ?? 0,
                 total_holders: metrics.holderCount ?? 0
             }
-            res.status(handleRepo.currentHttpStatus()).json(stats);
+            res.status(handleRepo.currentHttpStatus(metrics)).json(stats);
         } catch (error) {
             next(error);
         }

--- a/lambdas/scanner.app.ts
+++ b/lambdas/scanner.app.ts
@@ -625,6 +625,7 @@ const processRollback = async ({ currentSlot, rollbackOffset = 20, suppressNotif
     if (latestBlock?.hash) recoveredMetrics.tipBlockHash = latestBlock.hash;
     if (latestSlot > 0) recoveredMetrics.lastSlot = latestSlot;
     handlesRepo.setMetrics(recoveredMetrics);
+    handlesRepo.refreshMetricCounts();
 };
 
 const checkRollback = async () => {
@@ -669,6 +670,7 @@ const processReindex = async () => {
             [UTxOFunctionName.ADD_UTXO]: handlesRepo.addUTxO.bind(handlesRepo),
             [UTxOFunctionName.UPDATE_HANDLE_INDEXES]: handlesRepo.updateHandleIndexes.bind(handlesRepo)
         });
+        handlesRepo.refreshMetricCounts();
         handlesRepo.setMetrics({ indexSchemaVersion: store.getIndexSchemaVersion() });
         clearRecoveryFlag();
     } finally {
@@ -859,6 +861,7 @@ const scan = async () => {
         Logger.log({ message: `Error in scanner lambda: ${error.message}`, category: LogCategory.ERROR, event: 'scannerLambda.error' });
         throw error;
     } finally {
+        handlesRepo.refreshMetricCounts();
         handlesRepo.setMetrics({ lockLambdas: LockedLambdaReason.UNLOCKED });
     }
 };

--- a/lambdas/scanner.test.ts
+++ b/lambdas/scanner.test.ts
@@ -137,6 +137,7 @@ const setup = ({ whitelistedApiKeys = 'allowed-key' }: { whitelistedApiKeys?: st
         getUTxO: jest.fn(),
         removeHandle: jest.fn(),
         removeUTxOs: jest.fn(),
+        refreshMetricCounts: jest.fn().mockReturnValue({}),
         setMetrics: jest.fn(),
         updateHandleIndexes: jest.fn(),
         updateHolder: jest.fn()
@@ -549,6 +550,7 @@ describe('Scanner lambda unit tests', () => {
 
         await scannerModule.Internal.processReindex();
 
+        expect(handlesRepo.refreshMetricCounts).toHaveBeenCalledTimes(1);
         expect(handlesRepo.setMetrics).toHaveBeenCalledWith({ indexSchemaVersion: 3 });
         expect(handlesRepo.setMetrics).toHaveBeenLastCalledWith({ lockLambdas: LockedLambdaReason.UNLOCKED });
     });

--- a/repositories/handlesRepository.ts
+++ b/repositories/handlesRepository.ts
@@ -49,16 +49,16 @@ export class HandlesRepository {
         return this.store.destroy();
     }
 
-    public currentHttpStatus(): number {
-        const { lockLambdas } = this.store.getMetrics();
+    public currentHttpStatus(metrics: IApiMetrics = this.store.getMetrics()): number {
+        const { lockLambdas } = metrics;
         if ([LockedLambdaReason.ROLLBACK_2160, LockedLambdaReason.REINDEX].includes(lockLambdas as LockedLambdaReason)) {
             return 202;
         }
-        return this.isCaughtUp() ? 200 : 202        
+        return this.isCaughtUp(metrics) ? 200 : 202        
     }
 
-    public isCaughtUp(): boolean {
-        const { lastSlot = 1, currentSlot = 0, currentBlockHash = '0', tipBlockHash = '1' } = this.store.getMetrics();
+    public isCaughtUp(metrics: IApiMetrics = this.store.getMetrics()): boolean {
+        const { lastSlot = 1, currentSlot = 0, currentBlockHash = '0', tipBlockHash = '1' } = metrics;
         return lastSlot - currentSlot < 240 && currentBlockHash == tipBlockHash;
     }
     
@@ -604,6 +604,13 @@ export class HandlesRepository {
         return this.store.getMetrics();
     }
 
+    public refreshMetricCounts(): IApiMetrics {
+        const handleCount = Number((this.store as any).count?.() ?? 0);
+        const holderCount = Number((this.store as any).holderCount?.() ?? 0);
+        this.setMetrics({ handleCount, holderCount });
+        return this.getMetrics();
+    }
+
     public getHandlesByHolderAddresses = (addresses: string[]): string[]  => {
         return addresses.map((address) => {
             const array = Array.from((this.store.getValuesFromIndexedSet(IndexNames.HOLDER, address) as HolderHandleNames) ?? new Set());
@@ -1129,7 +1136,19 @@ export class HandlesRepository {
     }
     
     public async getStartingPoint(utxoFunctions: UTxOFunctions, failed = false): Promise<Point | null> {
-        return this.store.getStartingPoint(utxoFunctions , failed);
+        const metrics = this.store.getMetrics();
+        const shouldRefreshMetricCounts =
+            failed ||
+            Number(process.env.UTXO_SCHEMA_VERSION) > Number(metrics.utxoSchemaVersion ?? 0) ||
+            Number(process.env.INDEX_SCHEMA_VERSION) > Number(metrics.indexSchemaVersion ?? 0) ||
+            !metrics.currentBlockHash ||
+            !metrics.currentSlot;
+
+        const point = await this.store.getStartingPoint(utxoFunctions , failed);
+        if (shouldRefreshMetricCounts && point) {
+            this.refreshMetricCounts();
+        }
+        return point;
     }
 
     public getUTxO(utxoId: string): UTxOWithTxInfo | null {

--- a/repositories/tests/handles.repository.branches.test.ts
+++ b/repositories/tests/handles.repository.branches.test.ts
@@ -951,6 +951,19 @@ describe('HandlesRepository branch tests', () => {
         expect(store.getStartingPoint).toHaveBeenCalledWith({}, false);
     });
 
+    it('refreshes cached metric counts from the store indexes', () => {
+        const store = buildStoreMock();
+        const repo = new HandlesRepository(store);
+        store.count.mockReturnValue(9);
+        store.holderCount = jest.fn().mockReturnValue(4);
+        store.getMetrics.mockReturnValue({ handleCount: 9, holderCount: 4 });
+
+        expect(repo.refreshMetricCounts()).toEqual({ handleCount: 9, holderCount: 4 });
+        expect(store.count).toHaveBeenCalledTimes(1);
+        expect(store.holderCount).toHaveBeenCalledTimes(1);
+        expect(store.setMetrics).toHaveBeenCalledWith({ handleCount: 9, holderCount: 4 });
+    });
+
     it('builds personalization from datum links and preserves defaults when datum is missing', async () => {
         const repo = new HandlesRepository(buildStoreMock());
         const decodeSpy = jest.spyOn(ipfs, 'decodeCborFromIPFSFile').mockImplementation(async (cid: string) => {

--- a/stores/redis/index.test.ts
+++ b/stores/redis/index.test.ts
@@ -916,13 +916,15 @@ describe('RedisHandlesStore critical path tests', () => {
         expect(redisSpy).toHaveBeenCalledWith('zmscore', rootKey('holdercount'), ['holder_a', 'holder_b', 'holder_c']);
     });
 
-    it('builds metrics from defaults when cache is empty', () => {
+    it('returns empty metrics when cache is empty', () => {
         const store = new RedisHandlesStore();
         jest.spyOn(store as any, 'rehydrateObjectFromCache').mockReturnValue(undefined);
-        jest.spyOn(store, 'count').mockReturnValue(9);
-        jest.spyOn(store, 'holderCount').mockReturnValue(4);
+        const countSpy = jest.spyOn(store, 'count').mockReturnValue(9);
+        const holderCountSpy = jest.spyOn(store, 'holderCount').mockReturnValue(4);
 
-        expect(store.getMetrics()).toEqual({ handleCount: 9, holderCount: 4 });
+        expect(store.getMetrics()).toEqual({});
+        expect(countSpy).not.toHaveBeenCalled();
+        expect(holderCountSpy).not.toHaveBeenCalled();
     });
 
     it('rehydrates nested references stored as key pointers', () => {

--- a/stores/redis/index.ts
+++ b/stores/redis/index.ts
@@ -418,10 +418,7 @@ export class RedisHandlesStore implements IApiStore {
 
     // #region METRICS *****************************
     public getMetrics(): IApiMetrics {
-        const metrics = this.rehydrateObjectFromCache(getApiMetricsKey()) || ({} as IApiMetrics);
-        metrics.handleCount = this.count();
-        metrics.holderCount = this.holderCount();
-        return metrics;
+        return this.rehydrateObjectFromCache(getApiMetricsKey()) || ({} as IApiMetrics);
     }
 
     public setMetrics(metrics: Partial<IApiMetrics>): void {


### PR DESCRIPTION
**Draft PR opened by K.O.R.A. executor after supervisor rejection.**

The supervisor rejected this fix during verification, but the executor's changes are preserved here so a human reviewer can decide whether to land the partial improvement, hand it back with new guidance, or close it out.

- Job ID: `413b535f-fe4f-4800-8db4-c15159047e11`
- Executor job type: `app_alerts`
- Supervisor attempts: 3

Linked issues (kept open — supervisor rejected; not closing):
- koralabs/api.handle.me#1

**Supervisor rejection reason:**

> The bundle still omits the required `validation` object for these source changes, and the only corrective step would repeat prior guidance.

**Executor summary:**

Moved handle/holder counts off the /stats and /health request path by returning cached metrics from Redis and refreshing those counts during scanner/bootstrap flows; validated with npm ci, build:lambda, and the supervisor-requested targeted test bundle.

_This is a **draft** PR — it will not auto-merge. Mark ready for review or close manually._