### PR TITLE
[draft] App alert remediation for api.handle.me (api.timeout). First determine which repo owns this alert from the incident context, logs, and repo search. Then create a GitHub issue in that repo and continue remediation. Triage summary: 1 incident(s) detected for api.handle.me.. Suggested action: Proceed with standard incident response flow.. Evidence: dispatch:discord-3. Initial alert message: timeout exceeded. Health probe detail: https://west.api.handle.me /stats HTTP 0: connection_failed:timeout exceeded

### DIFF
--- a/controllers/health.controller.test.ts
+++ b/controllers/health.controller.test.ts
@@ -74,6 +74,7 @@ describe('HealthController', () => {
                 })
             })
         );
+        expect(repoMock.isCaughtUp).toHaveBeenCalledWith(baseMetrics);
         expect(res.json.mock.calls[0][0].ogmios).toBeUndefined();
         expect(next).not.toHaveBeenCalled();
     });

--- a/controllers/health.controller.ts
+++ b/controllers/health.controller.ts
@@ -26,7 +26,8 @@ class HealthController {
     public async index (req: Request, res: Response, next: NextFunction): Promise<void> {
         try {
             const handleRepo = new HandlesRepository(new (req.app.get('registry') as IRegistry).handlesStore());
-            const { firstSlot = 0, lastSlot = 0, currentSlot = 0, firstMemoryUsage = 0, currentBlockHash = '', tipBlockHash = '', memorySize = 0, utxoSchemaVersion = 0, indexSchemaVersion = 0, handleCount = 0, holderCount = 0, startTimestamp = 0, lockLambdas } = handleRepo.getMetrics();
+            const metrics = handleRepo.getMetrics();
+            const { firstSlot = 0, lastSlot = 0, currentSlot = 0, firstMemoryUsage = 0, currentBlockHash = '', tipBlockHash = '', memorySize = 0, utxoSchemaVersion = 0, indexSchemaVersion = 0, handleCount = 0, holderCount = 0, startTimestamp = 0, lockLambdas } = metrics;
             const handleSlotRange = lastSlot - firstSlot;
             const currentSlotInRange = currentSlot - firstSlot;
             const transpiredMs = Date.now() - startTimestamp;
@@ -53,7 +54,7 @@ class HealthController {
             };
 
             let status = HealthStatus.CURRENT;
-            if (!handleRepo.isCaughtUp()) {
+            if (!handleRepo.isCaughtUp(metrics)) {
                 status = HealthStatus.STORAGE_BEHIND;
             }
             const ogmiosScanningEnabled = process.env.ENABLE_OGMIOS_SCANNING?.toLocaleLowerCase() !== 'false';

--- a/controllers/mcp.controller.ts
+++ b/controllers/mcp.controller.ts
@@ -178,7 +178,7 @@ class MCPController {
         if (name === 'get_stats') {
             const metrics = handleRepo.getMetrics();
             return {
-                status: handleRepo.currentHttpStatus(),
+                status: handleRepo.currentHttpStatus(metrics),
                 total_handles: metrics.handleCount ?? 0,
                 total_holders: metrics.holderCount ?? 0
             };

--- a/controllers/stats.controller.test.ts
+++ b/controllers/stats.controller.test.ts
@@ -43,6 +43,7 @@ describe('StatsController', () => {
             total_handles: 0,
             total_holders: 7
         });
+        expect(repoMock.currentHttpStatus).toHaveBeenCalledWith({ handleCount: undefined, holderCount: 7 });
         expect(next).not.toHaveBeenCalled();
     });
 
@@ -63,6 +64,7 @@ describe('StatsController', () => {
             total_handles: 5,
             total_holders: 0
         });
+        expect(repoMock.currentHttpStatus).toHaveBeenCalledWith({ handleCount: 5, holderCount: undefined });
     });
 
     it('forwards unexpected repository errors to next', async () => {

--- a/controllers/stats.controller.ts
+++ b/controllers/stats.controller.ts
@@ -11,7 +11,7 @@ class StatsController {
                 total_handles: metrics.handleCount ?? 0,
                 total_holders: metrics.holderCount ?? 0
             }
-            res.status(handleRepo.currentHttpStatus()).json(stats);
+            res.status(handleRepo.currentHttpStatus(metrics)).json(stats);
         } catch (error) {
             next(error);
         }

--- a/docs/spec/runtime-entrypoints.md
+++ b/docs/spec/runtime-entrypoints.md
@@ -43,9 +43,12 @@ This document maps the code entrypoints, what they start, and which environment 
 ## Lambda Runtime
 
 ### API Lambda
-- `lambdas/api.ts` hydrates KMS environment variables, then loads `lambdas/api.app.ts`.
+- `lambdas/api.ts` identifies whether the invocation came from ALB or a Lambda Function URL (`requestContext.elb` vs `requestContext.http`), rejects unsupported event shapes, and only hydrates `WHITELISTED_API_KEYS` before boot when API rate limiting is enabled.
 - `lambdas/api.app.ts` forces `ENABLE_OGMIOS_SCANNING=false` and serves the Express API through `@vendia/serverless-express`.
+- The API Lambda caches separate `@vendia/serverless-express` adapters for `AWS_ALB` and `AWS_API_GATEWAY_V2` so warm invocations do not reuse the wrong event-source translation path.
 - This Lambda serves API traffic only. It does not run the Ogmios WebSocket scanner.
+- Function URL traffic uses the same read API routes as ALB traffic. Scanner-only shortcuts remain on `lambdas/scanner.ts`.
+- Provider secrets such as Koios, Blockfrost, and Pinata gateway tokens hydrate lazily at their request call sites instead of during API cold start.
 
 ### Scanner Lambda
 - `lambdas/scanner.ts` hydrates env and delegates to `lambdas/scanner.app.ts`.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -29,7 +29,7 @@ For external product context and Catalyst milestones, see `docs/product/ecosyste
 - Scanning mode:
   - Default: Ogmios WebSocket scanner (`services/ogmios/ogmios.service.ts`)
   - Optional local fallback in dev/test: scanner lambda loop (`USE_LAMBDA_SCANNER=true`)
-- Lambda mode (`lambdas/api.ts`) forces `ENABLE_OGMIOS_SCANNING=false` and serves API only.
+- Lambda mode (`lambdas/api.ts`) forces `ENABLE_OGMIOS_SCANNING=false`, serves API only, explicitly routes ALB versus Lambda Function URL events through the matching serverless adapter, and avoids decrypting unrelated provider secrets during API cold start.
 
 ## Data Freshness Contract
 - API returns `200` when store is caught up.

--- a/lambdas/api.app.ts
+++ b/lambdas/api.app.ts
@@ -1,12 +1,44 @@
 import serverlessExpress from '@vendia/serverless-express';
 import App from '../app';
+import type { ApiEventSourceName, ApiLambdaEvent } from './api';
+
 const app = new App();
 process.env.ENABLE_OGMIOS_SCANNING = 'false';
-let serverlessHandler: ReturnType<typeof serverlessExpress> | undefined;
+let lambdaAppPromise: Promise<{ app: unknown }> | undefined;
+let defaultServerlessHandler: ReturnType<typeof serverlessExpress> | undefined;
+const serverlessHandlers: Partial<Record<ApiEventSourceName, ReturnType<typeof serverlessExpress>>> = {};
 
-export const handler = async (event: AWSLambda.ALBEvent, context: AWSLambda.Context) => {
-    if (!serverlessHandler) {
-        serverlessHandler = serverlessExpress({ app: (await app.lambda()).app });
+const getLambdaApp = async () => {
+    if (!lambdaAppPromise) {
+        lambdaAppPromise = app.lambda();
     }
-    return (serverlessHandler as unknown as (event: AWSLambda.ALBEvent, context: AWSLambda.Context) => Promise<any>)(event, context);
+    return lambdaAppPromise;
+};
+
+const createServerlessHandler = async (eventSourceName?: ApiEventSourceName) => {
+    const { app: lambdaApp } = await getLambdaApp();
+    return serverlessExpress({
+        app: lambdaApp as Parameters<typeof serverlessExpress>[0]['app'],
+        ...(eventSourceName ? { eventSourceName } : {})
+    });
+};
+
+export const handler = async (
+    event: ApiLambdaEvent,
+    context: AWSLambda.Context,
+    options?: { eventSourceName?: ApiEventSourceName }
+) => {
+    const eventSourceName = options?.eventSourceName;
+    if (!eventSourceName) {
+        if (!defaultServerlessHandler) {
+            defaultServerlessHandler = await createServerlessHandler();
+        }
+        return (defaultServerlessHandler as unknown as (event: ApiLambdaEvent, context: AWSLambda.Context) => Promise<any>)(event, context);
+    }
+
+    if (!serverlessHandlers[eventSourceName]) {
+        serverlessHandlers[eventSourceName] = await createServerlessHandler(eventSourceName);
+    }
+
+    return (serverlessHandlers[eventSourceName] as unknown as (event: ApiLambdaEvent, context: AWSLambda.Context) => Promise<any>)(event, context);
 };

--- a/lambdas/api.test.ts
+++ b/lambdas/api.test.ts
@@ -3,15 +3,22 @@ describe('API lambda handler', () => {
         jest.resetModules();
         jest.clearAllMocks();
         delete process.env.ENABLE_OGMIOS_SCANNING;
+        delete process.env.RATE_LIMITER_ENABLED;
+        delete process.env.WHITELISTED_API_KEYS;
+        delete process.env.WHITELISTED_API_KEYS_ENC;
     });
 
-    it('exports an async non-callback handler wrapper', async () => {
-        const lambdaResponse = { statusCode: 200, body: 'ok' };
+    it('exports an async non-callback handler wrapper for ALB and Function URL events', async () => {
+        const albResponse = { statusCode: 200, body: 'alb' };
+        const functionUrlResponse = { statusCode: 200, body: 'function-url' };
         const appInstance = { app: { use: jest.fn() } };
         const appLambda = jest.fn().mockResolvedValue(appInstance);
         const AppMock = jest.fn().mockImplementation(() => ({ lambda: appLambda }));
-        const serverlessHandler = jest.fn().mockResolvedValue(lambdaResponse);
-        const serverlessExpress = jest.fn().mockReturnValue(serverlessHandler);
+        const albHandler = jest.fn().mockResolvedValue(albResponse);
+        const functionUrlHandler = jest.fn().mockResolvedValue(functionUrlResponse);
+        const serverlessExpress = jest.fn()
+            .mockReturnValueOnce(albHandler)
+            .mockReturnValueOnce(functionUrlHandler);
 
         jest.doMock('../app', () => ({ __esModule: true, default: AppMock }));
         jest.doMock('@vendia/serverless-express', () => ({ __esModule: true, default: serverlessExpress }));
@@ -21,24 +28,35 @@ describe('API lambda handler', () => {
             lambdaModule = await import('./api');
         });
 
-        const event = { requestContext: { elb: {} } } as any;
+        const albEvent = { requestContext: { elb: {} } } as any;
+        const functionUrlEvent = { requestContext: { http: { method: 'GET', path: '/stats' } }, rawPath: '/stats' } as any;
         const context = {} as any;
-        const result = await lambdaModule.handler(event, context);
+        const firstAlbResult = await lambdaModule.handler(albEvent, context);
+        const secondAlbResult = await lambdaModule.handler(albEvent, context);
+        const functionUrlResult = await lambdaModule.handler(functionUrlEvent, context);
 
         expect(process.env.ENABLE_OGMIOS_SCANNING).toBe('false');
         expect(AppMock).toHaveBeenCalledTimes(1);
         expect(appLambda).toHaveBeenCalledTimes(1);
-        expect(serverlessExpress).toHaveBeenCalledWith({ app: appInstance.app });
+        expect(serverlessExpress).toHaveBeenNthCalledWith(1, { app: appInstance.app, eventSourceName: 'AWS_ALB' });
+        expect(serverlessExpress).toHaveBeenNthCalledWith(2, { app: appInstance.app, eventSourceName: 'AWS_API_GATEWAY_V2' });
         expect(lambdaModule.handler.length).toBe(2);
-        expect(serverlessHandler).toHaveBeenCalledWith(event, context);
-        expect(serverlessHandler.mock.calls[0]).toHaveLength(2);
-        expect(result).toEqual(lambdaResponse);
+        expect(albHandler).toHaveBeenCalledTimes(2);
+        expect(albHandler).toHaveBeenCalledWith(albEvent, context);
+        expect(albHandler.mock.calls[0]).toHaveLength(2);
+        expect(functionUrlHandler).toHaveBeenCalledWith(functionUrlEvent, context);
+        expect(functionUrlHandler.mock.calls[0]).toHaveLength(2);
+        expect(firstAlbResult).toEqual(albResponse);
+        expect(secondAlbResult).toEqual(albResponse);
+        expect(functionUrlResult).toEqual(functionUrlResponse);
     });
 
-    it('hydrates before loading the API app module', async () => {
+    it('hydrates whitelisted api keys before loading the API app module when rate limiting is enabled', async () => {
         const lambdaResponse = { statusCode: 200, body: 'ok' };
         const event = { requestContext: { elb: {} } } as any;
         const context = {} as any;
+        process.env.RATE_LIMITER_ENABLED = 'true';
+        process.env.WHITELISTED_API_KEYS_ENC = 'ciphertext';
         let appLoaded = false;
         let hydrated = false;
         const appHandler = jest.fn().mockImplementation(async () => {
@@ -47,11 +65,12 @@ describe('API lambda handler', () => {
             }
             return lambdaResponse;
         });
-        const hydrateKmsEnvironment = jest.fn().mockImplementation(async () => {
+        const hydrateKmsKeysIfNeeded = jest.fn().mockImplementation(async (keys: string[]) => {
+            expect(keys).toEqual(['WHITELISTED_API_KEYS']);
             hydrated = true;
         });
 
-        jest.doMock('@koralabs/kora-labs-common', () => ({ hydrateKmsEnvironment }));
+        jest.doMock('../utils/kms', () => ({ hydrateKmsKeysIfNeeded }));
         jest.doMock('./api.app', () => {
             appLoaded = true;
             return { handler: appHandler };
@@ -65,7 +84,33 @@ describe('API lambda handler', () => {
         expect(appLoaded).toBe(false);
         await expect(lambdaModule.handler(event, context)).resolves.toEqual(lambdaResponse);
         expect(appLoaded).toBe(true);
-        expect(hydrateKmsEnvironment).toHaveBeenCalledTimes(1);
-        expect(appHandler).toHaveBeenCalledWith(event, context);
+        expect(hydrateKmsKeysIfNeeded).toHaveBeenCalledTimes(1);
+        expect(appHandler).toHaveBeenCalledWith(event, context, { eventSourceName: 'AWS_ALB' });
+    });
+
+    it('returns a 400 response for unsupported event sources without loading the app', async () => {
+        const context = {} as any;
+        let appLoaded = false;
+
+        jest.doMock('./api.app', () => {
+            appLoaded = true;
+            return { handler: jest.fn() };
+        });
+
+        let lambdaModule: any;
+        await jest.isolateModulesAsync(async () => {
+            lambdaModule = await import('./api');
+        });
+
+        await expect(lambdaModule.handler({ source: 'manual-test' } as any, context)).resolves.toEqual({
+            statusCode: 400,
+            headers: {
+                'content-type': 'application/json'
+            },
+            body: JSON.stringify({
+                message: 'Unsupported event source'
+            })
+        });
+        expect(appLoaded).toBe(false);
     });
 });

--- a/lambdas/api.ts
+++ b/lambdas/api.ts
@@ -1,7 +1,41 @@
-import { hydrateKmsEnvironment } from '@koralabs/kora-labs-common';
+import { hydrateKmsKeysIfNeeded } from '../utils/kms';
 
-export const handler = async (event: AWSLambda.ALBEvent, context: AWSLambda.Context) => {
-    await hydrateKmsEnvironment();
+export type ApiLambdaEvent = AWSLambda.ALBEvent | AWSLambda.APIGatewayProxyEventV2;
+export type ApiEventSourceName = 'AWS_ALB' | 'AWS_API_GATEWAY_V2';
+const API_BOOTSTRAP_KMS_KEYS = ['WHITELISTED_API_KEYS'];
+
+const getEventSourceName = (event: ApiLambdaEvent): ApiEventSourceName | null => {
+    if (event?.requestContext && 'http' in event.requestContext) {
+        return 'AWS_API_GATEWAY_V2';
+    }
+    if (event?.requestContext && 'elb' in event.requestContext) {
+        return 'AWS_ALB';
+    }
+    return null;
+};
+
+const buildUnsupportedEventResponse = () => {
+    return {
+        statusCode: 400,
+        headers: {
+            'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+            message: 'Unsupported event source'
+        })
+    };
+};
+
+export const handler = async (event: ApiLambdaEvent, context: AWSLambda.Context) => {
+    const eventSourceName = getEventSourceName(event);
+    if (!eventSourceName) {
+        return buildUnsupportedEventResponse();
+    }
+
+    if (process.env.RATE_LIMITER_ENABLED === 'true') {
+        await hydrateKmsKeysIfNeeded(API_BOOTSTRAP_KMS_KEYS);
+    }
+
     const { handler: appHandler } = await import('./api.app');
-    return appHandler(event, context);
+    return appHandler(event, context, { eventSourceName });
 };

--- a/lambdas/scanner.app.ts
+++ b/lambdas/scanner.app.ts
@@ -625,6 +625,7 @@ const processRollback = async ({ currentSlot, rollbackOffset = 20, suppressNotif
     if (latestBlock?.hash) recoveredMetrics.tipBlockHash = latestBlock.hash;
     if (latestSlot > 0) recoveredMetrics.lastSlot = latestSlot;
     handlesRepo.setMetrics(recoveredMetrics);
+    handlesRepo.refreshMetricCounts();
 };
 
 const checkRollback = async () => {
@@ -669,6 +670,7 @@ const processReindex = async () => {
             [UTxOFunctionName.ADD_UTXO]: handlesRepo.addUTxO.bind(handlesRepo),
             [UTxOFunctionName.UPDATE_HANDLE_INDEXES]: handlesRepo.updateHandleIndexes.bind(handlesRepo)
         });
+        handlesRepo.refreshMetricCounts();
         handlesRepo.setMetrics({ indexSchemaVersion: store.getIndexSchemaVersion() });
         clearRecoveryFlag();
     } finally {
@@ -859,6 +861,7 @@ const scan = async () => {
         Logger.log({ message: `Error in scanner lambda: ${error.message}`, category: LogCategory.ERROR, event: 'scannerLambda.error' });
         throw error;
     } finally {
+        handlesRepo.refreshMetricCounts();
         handlesRepo.setMetrics({ lockLambdas: LockedLambdaReason.UNLOCKED });
     }
 };

--- a/lambdas/scanner.test.ts
+++ b/lambdas/scanner.test.ts
@@ -137,6 +137,7 @@ const setup = ({ whitelistedApiKeys = 'allowed-key' }: { whitelistedApiKeys?: st
         getUTxO: jest.fn(),
         removeHandle: jest.fn(),
         removeUTxOs: jest.fn(),
+        refreshMetricCounts: jest.fn().mockReturnValue({}),
         setMetrics: jest.fn(),
         updateHandleIndexes: jest.fn(),
         updateHolder: jest.fn()
@@ -549,6 +550,7 @@ describe('Scanner lambda unit tests', () => {
 
         await scannerModule.Internal.processReindex();
 
+        expect(handlesRepo.refreshMetricCounts).toHaveBeenCalledTimes(1);
         expect(handlesRepo.setMetrics).toHaveBeenCalledWith({ indexSchemaVersion: 3 });
         expect(handlesRepo.setMetrics).toHaveBeenLastCalledWith({ lockLambdas: LockedLambdaReason.UNLOCKED });
     });

--- a/repositories/handlesRepository.ts
+++ b/repositories/handlesRepository.ts
@@ -49,16 +49,16 @@ export class HandlesRepository {
         return this.store.destroy();
     }
 
-    public currentHttpStatus(): number {
-        const { lockLambdas } = this.store.getMetrics();
+    public currentHttpStatus(metrics: IApiMetrics = this.store.getMetrics()): number {
+        const { lockLambdas } = metrics;
         if ([LockedLambdaReason.ROLLBACK_2160, LockedLambdaReason.REINDEX].includes(lockLambdas as LockedLambdaReason)) {
             return 202;
         }
-        return this.isCaughtUp() ? 200 : 202        
+        return this.isCaughtUp(metrics) ? 200 : 202
     }
 
-    public isCaughtUp(): boolean {
-        const { lastSlot = 1, currentSlot = 0, currentBlockHash = '0', tipBlockHash = '1' } = this.store.getMetrics();
+    public isCaughtUp(metrics: IApiMetrics = this.store.getMetrics()): boolean {
+        const { lastSlot = 1, currentSlot = 0, currentBlockHash = '0', tipBlockHash = '1' } = metrics;
         return lastSlot - currentSlot < 240 && currentBlockHash == tipBlockHash;
     }
     
@@ -604,6 +604,13 @@ export class HandlesRepository {
         return this.store.getMetrics();
     }
 
+    public refreshMetricCounts(): IApiMetrics {
+        const handleCount = Number((this.store as any).count?.() ?? 0);
+        const holderCount = Number((this.store as any).holderCount?.() ?? 0);
+        this.setMetrics({ handleCount, holderCount });
+        return this.getMetrics();
+    }
+
     public getHandlesByHolderAddresses = (addresses: string[]): string[]  => {
         return addresses.map((address) => {
             const array = Array.from((this.store.getValuesFromIndexedSet(IndexNames.HOLDER, address) as HolderHandleNames) ?? new Set());
@@ -1129,7 +1136,19 @@ export class HandlesRepository {
     }
     
     public async getStartingPoint(utxoFunctions: UTxOFunctions, failed = false): Promise<Point | null> {
-        return this.store.getStartingPoint(utxoFunctions , failed);
+        const metrics = this.store.getMetrics();
+        const shouldRefreshMetricCounts =
+            failed ||
+            Number(process.env.UTXO_SCHEMA_VERSION) > Number(metrics.utxoSchemaVersion ?? 0) ||
+            Number(process.env.INDEX_SCHEMA_VERSION) > Number(metrics.indexSchemaVersion ?? 0) ||
+            !metrics.currentBlockHash ||
+            !metrics.currentSlot;
+
+        const point = await this.store.getStartingPoint(utxoFunctions , failed);
+        if (shouldRefreshMetricCounts && point) {
+            this.refreshMetricCounts();
+        }
+        return point;
     }
 
     public getUTxO(utxoId: string): UTxOWithTxInfo | null {

--- a/repositories/tests/handles.repository.branches.test.ts
+++ b/repositories/tests/handles.repository.branches.test.ts
@@ -951,6 +951,55 @@ describe('HandlesRepository branch tests', () => {
         expect(store.getStartingPoint).toHaveBeenCalledWith({}, false);
     });
 
+    it('refreshes cached metric counts when recovery state requires a startup rebuild', async () => {
+        const store = buildStoreMock();
+        const repo = new HandlesRepository(store);
+        const point = { slot: 123, id: 'hash_123' };
+        store.getMetrics.mockReturnValue({
+            currentBlockHash: '',
+            currentSlot: 0,
+            utxoSchemaVersion: 0,
+            indexSchemaVersion: 0
+        });
+        store.getStartingPoint = jest.fn().mockResolvedValue(point);
+        const refreshMetricCountsSpy = jest.spyOn(repo, 'refreshMetricCounts').mockReturnValue({ handleCount: 9, holderCount: 4 } as any);
+
+        await expect(repo.getStartingPoint({} as any)).resolves.toEqual(point);
+
+        expect(store.getStartingPoint).toHaveBeenCalledWith({}, false);
+        expect(refreshMetricCountsSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not refresh cached metric counts when the starting point call is a no-op', async () => {
+        const store = buildStoreMock();
+        const repo = new HandlesRepository(store);
+        store.getMetrics.mockReturnValue({
+            currentBlockHash: 'tip',
+            currentSlot: 123,
+            utxoSchemaVersion: Number(process.env.UTXO_SCHEMA_VERSION),
+            indexSchemaVersion: Number(process.env.INDEX_SCHEMA_VERSION)
+        });
+        store.getStartingPoint = jest.fn().mockResolvedValue(null);
+        const refreshMetricCountsSpy = jest.spyOn(repo, 'refreshMetricCounts').mockReturnValue({} as any);
+
+        await expect(repo.getStartingPoint({} as any)).resolves.toBeNull();
+
+        expect(refreshMetricCountsSpy).not.toHaveBeenCalled();
+    });
+
+    it('refreshes cached metric counts from the store indexes', () => {
+        const store = buildStoreMock();
+        const repo = new HandlesRepository(store);
+        store.count.mockReturnValue(9);
+        store.holderCount = jest.fn().mockReturnValue(4);
+        store.getMetrics.mockReturnValue({ handleCount: 9, holderCount: 4 });
+
+        expect(repo.refreshMetricCounts()).toEqual({ handleCount: 9, holderCount: 4 });
+        expect(store.count).toHaveBeenCalledTimes(1);
+        expect(store.holderCount).toHaveBeenCalledTimes(1);
+        expect(store.setMetrics).toHaveBeenCalledWith({ handleCount: 9, holderCount: 4 });
+    });
+
     it('builds personalization from datum links and preserves defaults when datum is missing', async () => {
         const repo = new HandlesRepository(buildStoreMock());
         const decodeSpy = jest.spyOn(ipfs, 'decodeCborFromIPFSFile').mockImplementation(async (cid: string) => {

--- a/repositories/tests/repository.lifecycle.e2e.test.ts
+++ b/repositories/tests/repository.lifecycle.e2e.test.ts
@@ -1,4 +1,4 @@
-import { HandleType, HolderHandleNames, IPersonalization, IndexNames, StoredHandle, UTxO } from '@koralabs/kora-labs-common';
+import { HandleType, HolderHandleNames, IReferenceToken, IPersonalization, IndexNames, StoredHandle, UTxO } from '@koralabs/kora-labs-common';
 import { RedisHandlesStore } from '../../stores/redis';
 import { HandlesRepository } from '../handlesRepository';
 import { handlesFixture } from './fixtures/handles';
@@ -9,7 +9,7 @@ const address = 'addr_test1qzdzhdzf9ud8k2suzryvcdl78l3tfesnwp962vcuh99k8z834r3hj
 const movedAddress = 'addr_test1qz8zyhdetz270qzfvkym38wx4wsqzx0m49urfu3wjkqsuchs8t4235v9t0x5grxm2hel388ypz0q3fng8k6am5hqzacq0fc746';
 const movedHolder = 'stake_test1urcr464g6xz4hn2ypnd4tulcnnjq38sg5e5rmdwa6tspwuqn7lhlg';
 
-const defaultReferenceToken: UTxO = {
+const defaultReferenceToken: IReferenceToken = {
     tx_id: 'default_ref_tx',
     id: 'default_ref_tx#0',
     slot: 0,

--- a/shell/local_valkey.sh
+++ b/shell/local_valkey.sh
@@ -4,25 +4,57 @@ set -a && source .env && set +a
 REDIS_PORT=${REDIS_PORT:-6380}
 REDIS_HOST=${REDIS_HOST:-127.0.0.1}
 VALKEY_BIN=$(command -v valkey-server || true)
+VALKEY_VERSION=${VALKEY_VERSION:-8.1.6}
 
 if [ -z "${VALKEY_BIN}" ]
 then
+    VALKEY_RELEASE_OS="jammy"
     if [ "$(printf '%s\n' 24.04 "$(lsb_release -rs)" | sort -V | head -n1)" = "24.04" ]
     then
-        echo "Installing Valkey"
-        sudo apt install -y valkey
-        VALKEY_BIN=$(command -v valkey-server || true)
-    else
-        echo "You need to update your version of Ubuntu to at least 24.04 to install and run Valkey"
+        VALKEY_RELEASE_OS="noble"
+    fi
+
+    VALKEY_RELEASE_ARCH=$(uname -m)
+    case "${VALKEY_RELEASE_ARCH}" in
+        x86_64|amd64)
+            VALKEY_RELEASE_ARCH="x86_64"
+            ;;
+        aarch64|arm64)
+            VALKEY_RELEASE_ARCH="arm64"
+            ;;
+        *)
+            echo "Unsupported architecture for unattended Valkey bootstrap: ${VALKEY_RELEASE_ARCH}"
+            exit 1
+            ;;
+    esac
+
+    VALKEY_DOWNLOAD_DIR="${VALKEY_DOWNLOAD_DIR:-/tmp/valkey-${VALKEY_VERSION}-${VALKEY_RELEASE_OS}-${VALKEY_RELEASE_ARCH}}"
+    VALKEY_ARCHIVE="${VALKEY_DOWNLOAD_DIR}.tar.gz"
+    VALKEY_URL="https://download.valkey.io/releases/valkey-${VALKEY_VERSION}-${VALKEY_RELEASE_OS}-${VALKEY_RELEASE_ARCH}.tar.gz"
+    VALKEY_BIN="${VALKEY_DOWNLOAD_DIR}/bin/valkey-server"
+
+    if [ ! -x "${VALKEY_BIN}" ]
+    then
+        echo "Downloading Valkey ${VALKEY_VERSION} (${VALKEY_RELEASE_OS}/${VALKEY_RELEASE_ARCH})"
+        rm -rf "${VALKEY_DOWNLOAD_DIR}"
+        mkdir -p /tmp
+        curl -fsSL "${VALKEY_URL}" -o "${VALKEY_ARCHIVE}"
+        tar -xzf "${VALKEY_ARCHIVE}" -C /tmp
+    fi
+
+    if [ ! -x "${VALKEY_BIN}" ]
+    then
+        echo "Unable to prepare Valkey binary from ${VALKEY_URL}"
         exit 1
     fi
 fi
 
 if ! ss -lnt | grep -q ":${REDIS_PORT} "
 then
-    mkdir -p tmp
-    VALKEY_PIDFILE="${PWD}/tmp/valkey-${REDIS_PORT}.pid"
-    VALKEY_LOGFILE="${PWD}/tmp/valkey-${REDIS_PORT}.log"
+    VALKEY_TMP_DIR="${VALKEY_TMP_DIR:-/tmp/api-handle-me-valkey}"
+    mkdir -p "${VALKEY_TMP_DIR}"
+    VALKEY_PIDFILE="${VALKEY_TMP_DIR}/valkey-${REDIS_PORT}.pid"
+    VALKEY_LOGFILE="${VALKEY_TMP_DIR}/valkey-${REDIS_PORT}.log"
     echo "Starting test Valkey instance - connecting to ${REDIS_HOST}:${REDIS_PORT}"
     "${VALKEY_BIN}" \
         --bind "${REDIS_HOST}" \
@@ -30,7 +62,7 @@ then
         --save "" \
         --appendonly no \
         --daemonize yes \
-        --dir "${PWD}/tmp" \
+        --dir "${VALKEY_TMP_DIR}" \
         --pidfile "${VALKEY_PIDFILE}" \
         --logfile "${VALKEY_LOGFILE}"
 

--- a/stores/redis/index.test.ts
+++ b/stores/redis/index.test.ts
@@ -916,13 +916,15 @@ describe('RedisHandlesStore critical path tests', () => {
         expect(redisSpy).toHaveBeenCalledWith('zmscore', rootKey('holdercount'), ['holder_a', 'holder_b', 'holder_c']);
     });
 
-    it('builds metrics from defaults when cache is empty', () => {
+    it('returns empty metrics when cache is empty', () => {
         const store = new RedisHandlesStore();
         jest.spyOn(store as any, 'rehydrateObjectFromCache').mockReturnValue(undefined);
-        jest.spyOn(store, 'count').mockReturnValue(9);
-        jest.spyOn(store, 'holderCount').mockReturnValue(4);
+        const countSpy = jest.spyOn(store, 'count').mockReturnValue(9);
+        const holderCountSpy = jest.spyOn(store, 'holderCount').mockReturnValue(4);
 
-        expect(store.getMetrics()).toEqual({ handleCount: 9, holderCount: 4 });
+        expect(store.getMetrics()).toEqual({});
+        expect(countSpy).not.toHaveBeenCalled();
+        expect(holderCountSpy).not.toHaveBeenCalled();
     });
 
     it('rehydrates nested references stored as key pointers', () => {

--- a/stores/redis/index.ts
+++ b/stores/redis/index.ts
@@ -418,10 +418,7 @@ export class RedisHandlesStore implements IApiStore {
 
     // #region METRICS *****************************
     public getMetrics(): IApiMetrics {
-        const metrics = this.rehydrateObjectFromCache(getApiMetricsKey()) || ({} as IApiMetrics);
-        metrics.handleCount = this.count();
-        metrics.holderCount = this.holderCount();
-        return metrics;
+        return this.rehydrateObjectFromCache(getApiMetricsKey()) || ({} as IApiMetrics);
     }
 
     public setMetrics(metrics: Partial<IApiMetrics>): void {

--- a/utils/helpers.pagination.test.ts
+++ b/utils/helpers.pagination.test.ts
@@ -1,16 +1,50 @@
 import { Logger, NETWORK } from '@koralabs/kora-labs-common';
+import * as kms from './kms';
 import { blockfrostApiCall, fetchKoios, fetchPaginatedResults, fetchTxList } from './helpers';
+
+jest.mock('./kms', () => ({
+    hydrateKmsKeysIfNeeded: jest.fn()
+}));
 
 describe('helpers pagination tests', () => {
     const originalFetch = global.fetch;
     const originalBlockfrostApiKey = process.env.BLOCKFROST_API_KEY;
+    const originalBlockfrostApiKeyEnc = process.env.BLOCKFROST_API_KEY_ENC;
     const originalKoiosToken = process.env.KOIOS_API_BEARER_TOKEN;
+    const originalKoiosTokenEnc = process.env.KOIOS_API_BEARER_TOKEN_ENC;
 
     afterEach(() => {
         process.env.BLOCKFROST_API_KEY = originalBlockfrostApiKey;
+        process.env.BLOCKFROST_API_KEY_ENC = originalBlockfrostApiKeyEnc;
         process.env.KOIOS_API_BEARER_TOKEN = originalKoiosToken;
+        process.env.KOIOS_API_BEARER_TOKEN_ENC = originalKoiosTokenEnc;
         global.fetch = originalFetch;
         jest.restoreAllMocks();
+        (kms.hydrateKmsKeysIfNeeded as jest.Mock).mockReset();
+    });
+
+    it('blockfrostApiCall hydrates the API key lazily when only ciphertext is configured', async () => {
+        delete process.env.BLOCKFROST_API_KEY;
+        process.env.BLOCKFROST_API_KEY_ENC = 'ciphertext';
+        const hydrateSpy = kms.hydrateKmsKeysIfNeeded as jest.MockedFunction<typeof kms.hydrateKmsKeysIfNeeded>;
+        hydrateSpy.mockImplementation(async () => {
+            process.env.BLOCKFROST_API_KEY = 'lazy-key';
+        });
+        const fetchMock = jest.fn().mockResolvedValue({ status: 200, json: async () => ({}) });
+        global.fetch = fetchMock as any;
+
+        await blockfrostApiCall('blocks/latest');
+
+        expect(hydrateSpy).toHaveBeenCalledWith(['BLOCKFROST_API_KEY']);
+        expect(fetchMock).toHaveBeenCalledWith(
+            `https://cardano-${NETWORK.toLowerCase()}.blockfrost.io/api/v0/blocks/latest`,
+            {
+                headers: {
+                    project_id: 'lazy-key',
+                    'Content-Type': 'application/json'
+                }
+            }
+        );
     });
 
     it('blockfrostApiCall should call expected endpoint and headers', async () => {
@@ -123,6 +157,33 @@ describe('helpers pagination tests', () => {
                 }),
                 body: '{"_tx_hashes":["abc"]}',
                 signal: expect.anything()
+            })
+        );
+    });
+
+    it('fetchKoios hydrates the bearer token lazily when only ciphertext is configured', async () => {
+        delete process.env.KOIOS_API_BEARER_TOKEN;
+        process.env.KOIOS_API_BEARER_TOKEN_ENC = 'ciphertext';
+        const hydrateSpy = kms.hydrateKmsKeysIfNeeded as jest.MockedFunction<typeof kms.hydrateKmsKeysIfNeeded>;
+        hydrateSpy.mockImplementation(async () => {
+            process.env.KOIOS_API_BEARER_TOKEN = 'lazy-koios-token';
+        });
+        const koiosResponse = [{ tx_hash: 'abc' }];
+        const fetchMock = jest.fn().mockResolvedValue({
+            ok: true,
+            text: async () => JSON.stringify(koiosResponse)
+        });
+        global.fetch = fetchMock as any;
+
+        await fetchKoios('tx_info', 'POST', '{"_tx_hashes":["abc"]}');
+
+        expect(hydrateSpy).toHaveBeenCalledWith(['KOIOS_API_BEARER_TOKEN']);
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringMatching(/koios\.rest\/api\/v1\/tx_info$/),
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    Authorization: 'Bearer lazy-koios-token'
+                })
             })
         );
     });

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,11 +1,13 @@
 import { AssetNameLabel, delay, HANDLE_POLICIES, LogCategory, Logger, Network, NETWORK, UTxOWithTxInfo } from '@koralabs/kora-labs-common';
 import { KoiosTxInfo } from '../interfaces/provider.interface';
 import { getHandleNameFromAssetName } from '../services/ogmios/utils';
+import { hydrateKmsKeysIfNeeded } from './kms';
 
 export const defaultKoiosSettings = { _inputs: true, _withdrawals: false, _certs: false, _governance: false, _scripts: true, _bytecode: true, _metadata: true, _assets: true };
 const KOIOS_REQUEST_TIMEOUT_MS = 20_000;
 
 export const blockfrostApiCall = async (endpointSegment: string) => {
+    await hydrateKmsKeysIfNeeded(['BLOCKFROST_API_KEY']);
     const headers = {
         project_id: process.env.BLOCKFROST_API_KEY ?? '',
         'Content-Type': 'application/json'
@@ -59,6 +61,7 @@ export const fetchTxList = async (block: string) => {
 };
 
 export const fetchKoios = async (path: string, method = 'GET', body?: string) => {
+    await hydrateKmsKeysIfNeeded(['KOIOS_API_BEARER_TOKEN']);
     const url = `https://${NETWORK.toLowerCase() === 'mainnet' ? 'api' : NETWORK.toLowerCase()}.koios.rest/api/v1/${path}`;
     const koiosToken = process.env.KOIOS_API_BEARER_TOKEN?.trim();
     const headers: Record<string, string> = {

--- a/utils/ipfs/index.test.ts
+++ b/utils/ipfs/index.test.ts
@@ -1,14 +1,23 @@
 import * as cbor from '@koralabs/kora-labs-common/utils/cbor';
 import { Logger } from '@koralabs/kora-labs-common';
 import * as config from '../../config';
+import * as kms from '../kms';
 import { decodeCborFromIPFSFile } from './index';
 import * as ipfs from './requestIpfs';
 
 jest.mock('../../config');
+jest.mock('../kms', () => ({
+    hydrateKmsKeysIfNeeded: jest.fn()
+}));
 jest.mock('./requestIpfs');
 
 describe('decodeCborFromIPFSFile tests', () => {
+    const originalPinataGatewayToken = process.env.PINATA_GATEWAY_TOKEN;
+    const originalPinataGatewayTokenEnc = process.env.PINATA_GATEWAY_TOKEN_ENC;
+
     afterEach(() => {
+        process.env.PINATA_GATEWAY_TOKEN = originalPinataGatewayToken;
+        process.env.PINATA_GATEWAY_TOKEN_ENC = originalPinataGatewayTokenEnc;
         jest.clearAllMocks();
     });
 
@@ -26,6 +35,7 @@ describe('decodeCborFromIPFSFile tests', () => {
 
     it('should return hit the backup if first ipfs link was unsuccessful', async () => {
         jest.spyOn(config, 'getIpfsGateway').mockReturnValue('https://ipfs.io/ipfs/');
+        process.env.PINATA_GATEWAY_TOKEN = 'backup-token';
         const requestIpfsSpy = jest
             .spyOn(ipfs, 'requestIpfs')
             .mockResolvedValueOnce({
@@ -42,7 +52,35 @@ describe('decodeCborFromIPFSFile tests', () => {
         const result = await decodeCborFromIPFSFile(cid);
         expect(result).toEqual({ test: 'test' });
         expect(requestIpfsSpy).toBeCalledTimes(2);
-        expect(requestIpfsSpy).nthCalledWith(2, expect.stringMatching(new RegExp(`https://ipfs\\.io/ipfs/${cid}\\?pinataGatewayToken=`)));
+        expect(requestIpfsSpy).nthCalledWith(2, `https://ipfs.io/ipfs/${cid}?pinataGatewayToken=backup-token`);
+    });
+
+    it('hydrates the pinata token lazily before calling the backup gateway', async () => {
+        jest.spyOn(config, 'getIpfsGateway').mockReturnValue('https://ipfs.io/ipfs/');
+        delete process.env.PINATA_GATEWAY_TOKEN;
+        process.env.PINATA_GATEWAY_TOKEN_ENC = 'ciphertext';
+        const hydrateSpy = kms.hydrateKmsKeysIfNeeded as jest.MockedFunction<typeof kms.hydrateKmsKeysIfNeeded>;
+        hydrateSpy.mockImplementation(async () => {
+            process.env.PINATA_GATEWAY_TOKEN = 'lazy-backup-token';
+        });
+        const requestIpfsSpy = jest
+            .spyOn(ipfs, 'requestIpfs')
+            .mockResolvedValueOnce({
+                statusCode: 500,
+                cbor: undefined
+            })
+            .mockResolvedValueOnce({
+                statusCode: 200,
+                cbor: 'd879'
+            });
+        jest.spyOn(cbor, 'decodeCborToJson').mockResolvedValue({ test: 'test' });
+
+        const cid = 'zb2lazybackup';
+        const result = await decodeCborFromIPFSFile(cid);
+
+        expect(result).toEqual({ test: 'test' });
+        expect(hydrateSpy).toHaveBeenCalledWith(['PINATA_GATEWAY_TOKEN']);
+        expect(requestIpfsSpy).toHaveBeenLastCalledWith(`https://ipfs.io/ipfs/${cid}?pinataGatewayToken=lazy-backup-token`);
     });
 
     it('should unwrap constructor_0 encoded payloads', async () => {

--- a/utils/ipfs/index.ts
+++ b/utils/ipfs/index.ts
@@ -1,6 +1,7 @@
 import { LogCategory, Logger } from '@koralabs/kora-labs-common';
 import { decodeCborToJson } from '@koralabs/kora-labs-common/utils/cbor';
 import { getIpfsGateway } from '../../config';
+import { hydrateKmsKeysIfNeeded } from '../kms';
 import { requestIpfs } from './requestIpfs';
 
 export const decodeCborFromIPFSFile = async (cid: string, schema?: any): Promise<any> => {
@@ -16,7 +17,12 @@ export const decodeCborFromIPFSFile = async (cid: string, schema?: any): Promise
         if (result.statusCode !== 200) {
             ipfsGateway = getIpfsGateway(true);
             if (ipfsGateway.length > 12) {
-                result = await requestIpfs(`${ipfsGateway}${cid}?pinataGatewayToken=${process.env.PINATA_GATEWAY_TOKEN}`).catch((error: any) => {return {
+                await hydrateKmsKeysIfNeeded(['PINATA_GATEWAY_TOKEN']);
+                const pinataGatewayToken = process.env.PINATA_GATEWAY_TOKEN?.trim();
+                const backupGatewayUrl = pinataGatewayToken
+                    ? `${ipfsGateway}${cid}?pinataGatewayToken=${pinataGatewayToken}`
+                    : `${ipfsGateway}${cid}`;
+                result = await requestIpfs(backupGatewayUrl).catch((error: any) => {return {
                     statusCode: 500,
                     error: error.message,
                     cbor: undefined

--- a/utils/kms.ts
+++ b/utils/kms.ts
@@ -1,0 +1,25 @@
+import { hydrateKmsEnvironment } from '@koralabs/kora-labs-common';
+
+const hydrationPromises = new Map<string, Promise<void>>();
+
+export const hydrateKmsKeysIfNeeded = async (keys: string[]): Promise<void> => {
+    const uniqueKeys = [...new Set(keys)].filter(Boolean);
+
+    await Promise.all(uniqueKeys.map(async (key) => {
+        if (process.env[key] || !process.env[`${key}_ENC`]) {
+            return;
+        }
+
+        let hydration = hydrationPromises.get(key);
+        if (!hydration) {
+            hydration = hydrateKmsEnvironment({ keys: [key] })
+                .then(() => undefined)
+                .finally(() => {
+                    hydrationPromises.delete(key);
+                });
+            hydrationPromises.set(key, hydration);
+        }
+
+        await hydration;
+    }));
+};


### PR DESCRIPTION
**Draft PR opened by K.O.R.A. executor after supervisor rejection.**

The supervisor rejected this fix during verification, but the executor's changes are preserved here so a human reviewer can decide whether to land the partial improvement, hand it back with new guidance, or close it out.

- Job ID: `bcc6870e-7f2d-4546-8373-8847e05b85bb`
- Executor job type: `app_alerts`
- Supervisor attempts: 5

Linked issues (kept open — supervisor rejected; not closing):
- koralabs/api.handle.me#1

**Supervisor rejection reason:**

> runtime hit retry cap of 5 attempts; surfacing for human review. Last supervisor reason: The bundle claims validation in the summary, but it does not include the required structured validation object needed for approval.

**Executor summary:**

Remediated the api.timeout root cause in koralabs/api.handle.me by removing request-path Redis count scans from stats/health reads, refreshing cached counts during scanner maintenance, adding explicit Function URL vs ALB Lambda event handling, and validating with npm ci, build:lambda, unit tests, and e2e tests on Valkey port 6380. Local supervisor fix review approved the bundle.

_This is a **draft** PR — it will not auto-merge. Mark ready for review or close manually._