### PR TITLE
Configurable snapshot base URL (S3 → R2) for self-host

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -10,6 +10,7 @@ export const {
     OGMIOS_HOST = 'http://localhost:1337',
     NETWORK = '',
     DISABLE_HANDLES_SNAPSHOT = '',
+    SNAPSHOT_BASE_URL = 'http://api.handle.me.s3-website-us-west-2.amazonaws.com',
     WHITELISTED_API_KEYS = ''
 } = process.env;
 

--- a/stores/redis/index.ts
+++ b/stores/redis/index.ts
@@ -3,7 +3,7 @@ import { GlideString, HashDataType, SortOptions } from '@valkey/valkey-glide';
 import { promisify } from 'util';
 import { MessageChannel, receiveMessageOnPort, Worker } from 'worker_threads';
 import { inflate } from 'zlib';
-import { DISABLE_HANDLES_SNAPSHOT, NODE_ENV } from '../../config';
+import { DISABLE_HANDLES_SNAPSHOT, NODE_ENV, SNAPSHOT_BASE_URL } from '../../config';
 import { handleEraBoundaries, MAX_SETS_PER_PIPE, META_INDEXES, ORDERED_SLOTS } from '../../config/constants';
 import { getHandleNameFromAssetName } from '../../services/ogmios/utils';
 import { canonicalJsonStringify } from '../../utils/helpers';
@@ -178,7 +178,7 @@ export class RedisHandlesStore implements IApiStore {
         const startTime = Date.now();
         const currentUTxOSchemaVersion = this.getUTxOSchemaVersion();
         const fileName = 'handles_utxos.gz';
-        const url = `http://api.handle.me.s3-website-us-west-2.amazonaws.com/${NETWORK}/utxo-snapshot/${this.getUTxOSchemaVersion()}/${fileName}`;
+        const url = `${SNAPSHOT_BASE_URL}/${NETWORK}/utxo-snapshot/${this.getUTxOSchemaVersion()}/${fileName}`;
 
         // Resume-capable loader. Progress marker lives in the namespace as a
         // hash at {api:NETWORK}:snapshot_loader:progress. On fresh start we


### PR DESCRIPTION
Makes the handle-snapshot loader read its base URL from `SNAPSHOT_BASE_URL` instead of a hardcoded S3 website address.

- Default is unchanged (the current S3 URL), so existing deploys are unaffected.
- Self-hosted (AWS-exit) deploys set `SNAPSHOT_BASE_URL` to the Cloudflare R2 public URL, so the empty-DB data load comes from R2 instead of AWS S3.

The preview snapshot has already been copied to R2 (bucket `kora-snapshots`, public, verified byte-identical).

Follow-up (separate): the snapshot *writer* (`lambdas/snapshot.app.ts`) still writes to S3; it should write to R2 too once the writer side is migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)