### PR TITLE
Guard schema-version getters against NaN (prevent handle-index wipe)

### DIFF
--- a/stores/redis/index.ts
+++ b/stores/redis/index.ts
@@ -588,11 +588,29 @@ export class RedisHandlesStore implements IApiStore {
     }
 
     public getUTxOSchemaVersion(): number {
-        return Number(process.env.UTXO_SCHEMA_VERSION);
+        return this.requireSchemaVersion('UTXO_SCHEMA_VERSION');
     }
 
     public getIndexSchemaVersion(): number {
-        return Number(process.env.INDEX_SCHEMA_VERSION);
+        return this.requireSchemaVersion('INDEX_SCHEMA_VERSION');
+    }
+
+    // Resolve a schema-version env var, throwing if it is unset/invalid instead of returning
+    // NaN. An unset UTXO_SCHEMA_VERSION previously made tryPopulateFromS3UTxOs() build the URL
+    // `${SNAPSHOT_BASE_URL}/${NETWORK}/utxo-snapshot/NaN/handles_utxos.gz`, fetch an empty
+    // object, and clearNamespace() — silently WIPING the handle index. Failing loud here
+    // aborts before clearNamespace() runs, so a misconfigured deploy can't destroy the index.
+    private requireSchemaVersion(envName: 'UTXO_SCHEMA_VERSION' | 'INDEX_SCHEMA_VERSION'): number {
+        const raw = process.env[envName];
+        const value = Number(raw);
+        if (raw === undefined || raw === '' || !Number.isInteger(value) || value < 1) {
+            throw new Error(
+                `${envName} must be a positive integer (got ${JSON.stringify(raw)}). ` +
+                    `Refusing to proceed: an unset/invalid schema version resolves the snapshot URL to ` +
+                    `'.../utxo-snapshot/NaN/...', which loads an empty snapshot and wipes the handle index.`
+            );
+        }
+        return value;
     }
 
     // #endregion


### PR DESCRIPTION
## Problem

`RedisHandlesStore.getUTxOSchemaVersion()` / `getIndexSchemaVersion()` returned `Number(process.env.X)`, which is **`NaN`** when the env var is unset. In `tryPopulateFromS3UTxOs()` that `NaN` flows straight into the snapshot URL:

```
${SNAPSHOT_BASE_URL}/${NETWORK}/utxo-snapshot/NaN/handles_utxos.gz
```

That object doesn't exist (or is an empty 85-byte file), so the loader takes the "fresh start" path and runs `clearNamespace()` — **silently wiping the handle index** (`handle_count → 0`, API serves 404/`STORAGE_BEHIND`). It bit a self-hosted deploy twice: any environment missing `UTXO_SCHEMA_VERSION` destroys the index on the next scanner run.

## Fix

Resolve both getters through a new `requireSchemaVersion()` that **throws on an unset/invalid value** instead of returning `NaN`. The getter is called *before* `clearNamespace()`, so failing loud aborts the load before it can clear anything. A misconfigured deploy now errors visibly instead of emptying the namespace.

No behavior change when the env is set correctly (positive integer) — it returns the same number as before.

## Notes
- Targets `preview` (the self-host-deployed branch); worth cherry-picking to `mainnet`.
- Defense-in-depth on the operator side also exists in the self-host bootstrap (it sets these vars with safe defaults and refuses to schedule the scanner if they're missing), but the real fix belongs here so the index can't be wiped regardless of how the function is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)