### PR TITLE
Add focused coverage tests

### DIFF
--- a/middlewares/discovery.middleware.test.ts
+++ b/middlewares/discovery.middleware.test.ts
@@ -1,0 +1,20 @@
+import packageJson from '../package.json';
+import discoveryMiddleware from './discovery.middleware';
+
+const makeResponse = () => ({
+    set: jest.fn()
+} as any);
+
+describe('discoveryMiddleware', () => {
+    it('adds service discovery links and the current API version header', () => {
+        const res = makeResponse();
+        const next = jest.fn();
+
+        discoveryMiddleware({} as any, res, next);
+
+        expect(res.set).toHaveBeenCalledWith('Link', expect.stringContaining('</swagger/swagger.yml>; rel="service-doc"; type="application/yaml"'));
+        expect(res.set).toHaveBeenCalledWith('Link', expect.stringContaining('</mcp>; rel="service-meta"; type="application/json"'));
+        expect(res.set).toHaveBeenCalledWith('X-API-Version', packageJson.version);
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+});

--- a/services/ogmios/tests/manualRollback.test.ts
+++ b/services/ogmios/tests/manualRollback.test.ts
@@ -1,0 +1,65 @@
+import { Logger } from '@koralabs/kora-labs-common';
+import { manualRollback } from '../utils/manualRollback';
+
+describe('manualRollback', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+    });
+
+    it('emits the default RollBackward request after the default timeout', () => {
+        const processMessage = jest.fn().mockResolvedValue(undefined);
+        const loggerSpy = jest.spyOn(Logger, 'log').mockImplementation(jest.fn());
+
+        manualRollback(processMessage);
+
+        jest.advanceTimersByTime(34999);
+        expect(processMessage).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(1);
+
+        expect(loggerSpy).toHaveBeenCalledWith('PERFORMING ROLLBACK!!!');
+        expect(processMessage).toHaveBeenCalledTimes(1);
+
+        const payload = JSON.parse(processMessage.mock.calls[0][0] as string);
+        expect(payload).toEqual(expect.objectContaining({
+            type: 'jsonwsp/response',
+            version: '1.0',
+            servicename: 'ogmios',
+            methodname: 'RequestNext',
+            reflection: null
+        }));
+        expect(payload.result.RollBackward.point).toEqual({
+            slot: 13631415,
+            hash: 'a0177bc9ad5cc0a04ea5ccd3b5e3817ef33d885156434e4f0de34847dcfc114a'
+        });
+        expect(payload.result.RollBackward.tip).toEqual({
+            slot: 17288960,
+            hash: 'f69cbe83f0129c7691b61e96ddb16805751f54aa3e2ea7e1e17cb2fb837e4d81',
+            blockNo: 487552
+        });
+    });
+
+    it('uses caller provided timeout and rollback point', () => {
+        const processMessage = jest.fn().mockResolvedValue(undefined);
+        jest.spyOn(Logger, 'log').mockImplementation(jest.fn());
+
+        manualRollback(processMessage, 25, 42, 'custom-rollback-hash');
+
+        jest.advanceTimersByTime(24);
+        expect(processMessage).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(1);
+
+        const payload = JSON.parse(processMessage.mock.calls[0][0] as string);
+        expect(payload.result.RollBackward.point).toEqual({
+            slot: 42,
+            hash: 'custom-rollback-hash'
+        });
+    });
+});

--- a/utils/contentNegotiation.test.ts
+++ b/utils/contentNegotiation.test.ts
@@ -1,0 +1,37 @@
+import { wantsJsonForDecoding, wantsRawCbor, wantsTextPlain } from './contentNegotiation';
+
+const requestWithAccept = (accept?: string) => ({
+    headers: accept === undefined ? {} : { accept }
+} as any);
+
+describe('contentNegotiation', () => {
+    it('defaults missing Accept headers to JSON semantics', () => {
+        const req = requestWithAccept();
+
+        expect(wantsTextPlain(req)).toBe(false);
+        expect(wantsRawCbor(req)).toBe(false);
+        expect(wantsJsonForDecoding(req)).toBe(true);
+    });
+
+    it('prefers JSON when the client advertises JSON, text, and wildcards', () => {
+        const req = requestWithAccept('application/json, text/plain, */*');
+
+        expect(wantsTextPlain(req)).toBe(false);
+        expect(wantsRawCbor(req)).toBe(false);
+        expect(wantsJsonForDecoding(req)).toBe(true);
+    });
+
+    it('matches text/plain with parameters when JSON is not requested', () => {
+        const req = requestWithAccept('text/plain; charset=utf-8');
+
+        expect(wantsTextPlain(req)).toBe(true);
+        expect(wantsRawCbor(req)).toBe('text/plain');
+        expect(wantsJsonForDecoding(req)).toBe(false);
+    });
+
+    it('recognizes explicit CBOR representations without treating application wildcards as raw', () => {
+        expect(wantsRawCbor(requestWithAccept('application/cbor'))).toBe('application/cbor');
+        expect(wantsRawCbor(requestWithAccept('application/cbor-hex'))).toBe('application/cbor-hex');
+        expect(wantsRawCbor(requestWithAccept('application/*'))).toBe(false);
+    });
+});


### PR DESCRIPTION
Summary:
- Add coverage for manualRollback timer/payload behavior.
- Add coverage for content negotiation Accept-header behavior.
- Add coverage for discovery middleware headers.

Verify:
- UTXO_SCHEMA_VERSION=1 INDEX_SCHEMA_VERSION=1 npm test (pass: 49 unit suites/573 tests; 8 e2e suites/65 tests).