### PR TITLE
Validate handles list body entries

### DIFF
--- a/controllers/handles.controller.ts
+++ b/controllers/handles.controller.ts
@@ -126,6 +126,20 @@ class HandlesController {
         }
     }
 
+    private static validateStringListBody(body: unknown): string[] {
+        if (isEmpty(body)) {
+            return [];
+        }
+        if (!Array.isArray(body)) {
+            throw ApiError.invalidListBody('expected array and received object');
+        }
+        const invalidEntry = body.find((handle) => typeof handle !== 'string');
+        if (invalidEntry !== undefined) {
+            throw ApiError.invalidListBody(`expected string entries and received ${Array.isArray(invalidEntry) ? 'array' : typeof invalidEntry}`);
+        }
+        return body;
+    }
+
     private static async _searchFromList (req: Request<Request, {}, ISearchBody, IGetAllQueryParams>, res: Response, handles?: ISearchBody): Promise<void> {
         const handleRepo: HandlesRepository = new HandlesRepository(new (req.app.get('registry') as IRegistry).handlesStore());
         const handleSearchResults = HandlesController.parseQueryAndSearchHandles(req, handleRepo, handles)
@@ -148,7 +162,7 @@ class HandlesController {
     public async list (req: Request<Request, {}, ISearchBody, IGetAllQueryParams>, res: Response, next: NextFunction): Promise<void> {
         try {
             const handleRepo: HandlesRepository = new HandlesRepository(new (req.app.get('registry') as IRegistry).handlesStore());
-            let handles: string[] = !isEmpty(req.body) ? req.body as string[] : [];
+            let handles = HandlesController.validateStringListBody(req.body);
             switch (req.query.type) {
                 case 'bech32stake':
                 case 'holder':

--- a/routes/handles.route.test.ts
+++ b/routes/handles.route.test.ts
@@ -567,6 +567,18 @@ describe('Testing Handles Routes', () => {
             expect(response.body).toEqual([{ name: 'burritos', utxo: 'utxo#0', policy: 'f0ff' }]);
         });
 
+        it('should reject object entries for stake key hash lookup without a 500', async () => {
+            const response = await request(app?.getServer())
+                .post('/handles/list?type=stakekeyhash')
+                .set('Content-Type', 'application/json')
+                .send([{ hash: 'deadbeef' }]);
+
+            expect(response.status).toEqual(400);
+            expect(response.body.message).toEqual('expected string entries and received object');
+            const repoInstance = MockedHandlesRepository.mock.results.at(-1)?.value;
+            expect(repoInstance.getHandlesByStakeKeyHashes).not.toHaveBeenCalled();
+        });
+
         it('should return text/plain handle list from list search', async () => {
             const response = await request(app?.getServer())
                 .post('/handles/list?records_per_page=1&sort=asc')

--- a/utils/apiError.ts
+++ b/utils/apiError.ts
@@ -100,6 +100,10 @@ export class ApiError extends HttpException {
         );
     }
 
+    static invalidListBody(message = 'expected array of strings'): ApiError {
+        return new ApiError(400, 'bad_request', message);
+    }
+
     static handleTypeUnsupportedForMint(): ApiError {
         return new ApiError(
             400,


### PR DESCRIPTION
Reject non-string /handles/list body entries before type-specific reverse lookup so stakekeyhash payloads cannot reach crypto hashing as objects. Verify: npm test passed (51 unit suites, 8 e2e suites).