### PR TITLE
Handle malformed stake key hash list inputs

### DIFF
--- a/repositories/handlesRepository.ts
+++ b/repositories/handlesRepository.ts
@@ -738,6 +738,9 @@ export class HandlesRepository {
 
     public getHandlesByStakeKeyHashes = (hashes: string[]): string[]  => {
         return hashes.map((h) => {
+            if (!/^[0-9a-fA-F]*$/.test(h) || h.length % 2 !== 0) {
+                return [EMPTY];
+            }
             const hashed = crypto.createHash('md5').update(h, 'hex').digest('hex');
             const array = Array.from(this.store.getValuesFromIndexedSet(IndexNames.HASH_OF_STAKE_KEY_HASH, hashed!) ?? []);
             return array.length === 0 ? [EMPTY] : array;

--- a/repositories/tests/handles.repository.branches.test.ts
+++ b/repositories/tests/handles.repository.branches.test.ts
@@ -485,6 +485,7 @@ describe('HandlesRepository branch tests', () => {
 
         expect(repo.getHandlesByHolderAddresses(['invalid-address'])).toEqual([EMPTY, EMPTY]);
         expect(repo.getHandlesByStakeKeyHashes(['deadbeef'])).toEqual([EMPTY]);
+        expect(repo.getHandlesByStakeKeyHashes(['abcde', 'not-hex'])).toEqual([EMPTY, EMPTY]);
         expect(repo.getHandlesByPaymentKeyHashes(['deadbeef'])).toEqual([EMPTY]);
         expect(repo.getHandlesByAddresses(['addr_test1_missing'])).toEqual([EMPTY]);
     });


### PR DESCRIPTION
Guard stakekeyhash list lookup against malformed odd-length or non-hex inputs so POST /handles/list?type=stakekeyhash returns EMPTY fallbacks instead of throwing from crypto.update. Verify: npm test passed (51 unit suites, 8 e2e suites).