### PR TITLE
feat(valkey-utility): trigger_reindex + reindex-without-reimport runbook

### DIFF
--- a/docs/spec/scanner-recovery-runbook.md
+++ b/docs/spec/scanner-recovery-runbook.md
@@ -99,6 +99,54 @@ The scanner falls back to Blockfrost when Koios calls fail. If both providers ar
 
 6. **API Lambda stale cache** — After reimport, the API Lambda may show `slot: 0` or `percentage_complete: 0` for up to 30 minutes until its warm instances cycle out. The data in Valkey is correct — verify with valkey-utility.
 
+## Reindex Without Reimport (recompute indexes, no schema bump)
+
+Use this when a **secondary index's membership changed additively** but its shape/contract did
+**not** — e.g. broadening the `is_personalized` predicate so `PERSONALIZED` also counts custom
+(non-`ada`) chain addresses. This rebuilds the secondary indexes from the UTxOs **already in
+Valkey** — no S3 reimport, no chain rescan (~5 min for ~265K handles).
+
+> ⚠️ This is **not** a schema-version bump. Do **not** touch `INDEX_SCHEMA_VERSION` /
+> `UTXO_SCHEMA_VERSION` — they are a breaking-change contract published on `/health`
+> (see [`schema-versions.md`](./schema-versions.md)). Adding a field or broadening index membership
+> is additive; bumping would falsely tell every consumer the schema broke.
+
+**Mechanism:** set the recovery flag `{api:<network>}:scanner:recovery = reindex`. The next
+scheduled scanner tick reads it (`scanner.app.ts`: `getRecoveryFlag()` → `processReindex()` →
+`repopulateIndexesFromUTxOs()`), rebuilds indexes with the **currently deployed code**, then clears
+the flag. `indexSchemaVersion` / `utxoSchemaVersion` stay untouched. On AWS the scanner runs this
+in-process (`KORA_SCANNER_DEFER_IMPORTS` is unset); the 409/deferred path is box-only.
+
+**Procedure — one region at a time, east verified before west:**
+1. Deploy the code first (the predicate must live in a single shared helper used by both the view
+   model field and the index `save()`, e.g. `utils/isPersonalized.ts`).
+2. Bump that region's `api-scanner` to **10GB** (`update-function-configuration --memory-size 10240`
+   → `wait function-updated` → `publish-version` → `update-alias <network>`; verify `NETWORK`). The
+   rebuild iterates every handle and OOMs at 4GB.
+3. `valkey-utility` **`trigger_reindex`** (sets the recovery flag):
+   ```bash
+   aws lambda invoke --function-name valkey-utility --region us-east-1 \
+       --cli-binary-format raw-in-base64-out \
+       --payload '{"action":"trigger_reindex","region":"us-east-1","network":"mainnet"}' /tmp/r.json
+   ```
+4. Watch the region's metrics: `lockLambdas` goes `REINDEX` (~5 min), then clears; the recovery flag
+   returns to `null`; the scanner resumes `SCANNING` and catches back to tip
+   (`currentBlockHash == tipBlockHash`).
+5. Verify (`indexSchemaVersion` unchanged, the affected filter e.g. `?personalized=true` returns
+   200, region at tip).
+6. Restore that region's scanner to **4GB** (config → publish → alias).
+7. Repeat for the other region.
+
+> ⚠️ **`api.handle.me` is CNAME'd to the _west_ ELB only — there is NO Route53/east failover.**
+> `east.api.handle.me` is the east-direct endpoint. Consequences during a reindex:
+> - A **west** reindex briefly degrades the **main** `api.handle.me` (~5 min). It returns **HTTP
+>   `202` with the full handle body** — "a region is reindexing", not an error — but consumers that
+>   reject non-`200` will see it. Prefer low-traffic windows for west.
+> - An **east** reindex only affects `east.api.handle.me`; main traffic is unaffected.
+>
+> Done 2026-06-22 for `is_personalized` (api.handle.me#199), both regions, on the eef2391-based
+> mainnet deploy. `trigger_reindex` is a permanent `valkey-utility` action.
+
 ## Valkey-Utility Usage
 
 The `valkey-utility` Lambda is ad hoc throwaway code. Deploy whatever handler you need:

--- a/lambdas/valkeyutility.ts
+++ b/lambdas/valkeyutility.ts
@@ -107,7 +107,8 @@ type Action =
     | 'scard'
     | 'sdiff_count'
     | 'smembers_diff'
-    | 'reset_scanner';
+    | 'reset_scanner'
+    | 'trigger_reindex';
 
 type ValkeyEvent = {
     action?: Action;
@@ -882,6 +883,22 @@ const inspect = async (event: ValkeyEvent) => {
             const after = await target.hgetall(metricsKey);
             return { network, metricsKey, progressKey, progressDeleted, before, after };
         }
+        if (action === 'trigger_reindex') {
+            // Force an in-place secondary-index rebuild (repopulateIndexesFromUTxOs) on the next
+            // scanner tick — WITHOUT a UTXO reimport and WITHOUT an INDEX_SCHEMA_VERSION bump.
+            // Sets the scanner recovery flag the scheduled scanner reads (scanner.app.ts:
+            // getRecoveryFlag() !== 'rollback' -> processReindex()). Use this when an index's
+            // *membership* changed but its shape/contract did not (so a schema-version bump —
+            // which signals a breaking change to consumers — would be wrong). NOTE: the rebuild
+            // iterates every handle; bump api-scanner to 10GB BEFORE invoking this, or it OOMs at
+            // 4GB. The scanner sets lockLambdas:REINDEX itself while it runs.
+            const network = requireNetwork(event);
+            const recoveryKey = `${getApiCacheTag(network)}:scanner:recovery`;
+            const before = await target.get(recoveryKey);
+            await target.set(recoveryKey, 'reindex');
+            const after = await target.get(recoveryKey);
+            return { action: 'trigger_reindex', network, recoveryKey, before, after };
+        }
         // Default status: read the requested network's MPT root + scanner metrics.
         // Network is required — no silent default. (See requireNetwork: a missing
         // network used to default to mainnet, so an empty {} payload mutated mainnet.)
@@ -915,6 +932,7 @@ export const handler = async (event: ValkeyEvent = {}) => {
             case 'sdiff_count':
             case 'smembers_diff':
             case 'reset_scanner': result = await inspect(event); break;
+            case 'trigger_reindex': result = await inspect(event); break;
             default: result = await inspectMetrics(event); break;
         }
         console.log(JSON.stringify(result, jsonReplacer));


### PR DESCRIPTION
## What
- New `valkey-utility` action **`trigger_reindex`** — sets `{api:<network>}:scanner:recovery=reindex` so the next scheduled scanner tick runs `processReindex()` → `repopulateIndexesFromUTxOs()`, rebuilding the secondary indexes from the UTxOs **already in Valkey**. No S3 reimport, no chain rescan, **no `INDEX_SCHEMA_VERSION` bump**.
- New runbook section **"Reindex Without Reimport"** in `docs/spec/scanner-recovery-runbook.md`: per-region 10GB dance, verify, restore 4GB, and the `api.handle.me`-is-west-pinned (no east failover) gotcha.

## Why
The `is_personalized` predicate (api.handle.me#199) broadened to count custom chain addresses, so the `PERSONALIZED` index membership needed recomputing — an **additive** change, not a breaking schema change. Bumping a schema version to "force a reindex" is wrong (it's a consumer-facing breaking-change contract — see `docs/spec/schema-versions.md`). `trigger_reindex` is the correct lever.

## Already executed on mainnet (2026-06-22)
Both regions reindexed via this action (east → west, one at a time), scanners restored to 4GB, `idxVer` stayed `3`. `valkey-utility` was hand-deployed (`update-function-code`) to both regions; this PR lands the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)