### PR TITLE
test: add focused coverage for api.handle.me

### DIFF
--- a/routes/mptRoot.route.test.ts
+++ b/routes/mptRoot.route.test.ts
@@ -1,0 +1,47 @@
+import MptRootRoute from './mptRoot.route';
+
+const findRouteLayer = (route: MptRootRoute, path: string) =>
+    (route.router as any).stack.find((layer: any) => layer.route?.path === path);
+
+describe('MptRootRoute tests', () => {
+    it('initializes all MPT root GET endpoints with their query guards', () => {
+        const route = new MptRootRoute();
+
+        expect(route.path).toEqual('/mpt-root');
+
+        const indexLayer = findRouteLayer(route, '/mpt-root');
+        const proofLayer = findRouteLayer(route, '/mpt-root/proof');
+        const registryLabelsLayer = findRouteLayer(route, '/mpt-root/registry-labels');
+
+        expect(indexLayer.route.methods.get).toBe(true);
+        expect(proofLayer.route.methods.get).toBe(true);
+        expect(registryLabelsLayer.route.methods.get).toBe(true);
+        expect(indexLayer.route.stack).toHaveLength(2);
+        expect(proofLayer.route.stack).toHaveLength(2);
+        expect(registryLabelsLayer.route.stack).toHaveLength(2);
+    });
+
+    it('only allows proof-specific query parameters on the proof endpoint', () => {
+        const route = new MptRootRoute();
+        const proofLayer = findRouteLayer(route, '/mpt-root/proof');
+        const guard = proofLayer.route.stack[0].handle;
+        const next = jest.fn();
+
+        guard({ query: { handle: 'alice', label: '00001070', amount: '1' } }, {}, next);
+
+        expect(next).toHaveBeenCalledWith();
+    });
+
+    it('rejects query parameters on endpoints that do not accept them', () => {
+        const route = new MptRootRoute();
+        const indexLayer = findRouteLayer(route, '/mpt-root');
+        const guard = indexLayer.route.stack[0].handle;
+        const next = jest.fn();
+
+        guard({ query: { handle: 'alice' } }, {}, next);
+
+        const err = next.mock.calls[0][0];
+        expect(err.status).toBe(400);
+        expect(err.code).toBe('unknown_query_params');
+    });
+});

--- a/utils/contentNegotiation.test.ts
+++ b/utils/contentNegotiation.test.ts
@@ -1,0 +1,50 @@
+import { Request } from 'express';
+import { wantsJsonForDecoding, wantsRawCbor, wantsTextPlain } from './contentNegotiation';
+
+const makeReq = (accept?: string) => ({
+    headers: accept === undefined ? {} : { accept }
+} as Request<any, any, any, any>);
+
+describe('contentNegotiation', () => {
+    describe('wantsTextPlain', () => {
+        it('defaults to JSON when Accept is missing or wildcard', () => {
+            expect(wantsTextPlain(makeReq())).toBe(false);
+            expect(wantsTextPlain(makeReq('*/*'))).toBe(false);
+        });
+
+        it('prefers JSON when application/json is listed alongside text/plain', () => {
+            expect(wantsTextPlain(makeReq('application/json, text/plain, */*'))).toBe(false);
+            expect(wantsTextPlain(makeReq('text/plain, application/json'))).toBe(false);
+        });
+
+        it('detects explicit text/plain even with parameters', () => {
+            expect(wantsTextPlain(makeReq('text/plain; charset=utf-8'))).toBe(true);
+        });
+    });
+
+    describe('wantsRawCbor', () => {
+        it('defaults to decoded JSON unless a raw type is explicitly requested', () => {
+            expect(wantsRawCbor(makeReq())).toBe(false);
+            expect(wantsRawCbor(makeReq('*/*'))).toBe(false);
+            expect(wantsRawCbor(makeReq('application/json'))).toBe(false);
+        });
+
+        it('returns the first supported raw response type requested by the client', () => {
+            expect(wantsRawCbor(makeReq('application/cbor'))).toBe('application/cbor');
+            expect(wantsRawCbor(makeReq('application/cbor-hex'))).toBe('application/cbor-hex');
+            expect(wantsRawCbor(makeReq('text/plain; charset=utf-8'))).toBe('text/plain');
+        });
+
+        it('keeps JSON preferred when raw and JSON types are both listed', () => {
+            expect(wantsRawCbor(makeReq('application/cbor, application/json'))).toBe(false);
+        });
+    });
+
+    describe('wantsJsonForDecoding', () => {
+        it('is true for default JSON behavior and false for raw CBOR opt-in', () => {
+            expect(wantsJsonForDecoding(makeReq())).toBe(true);
+            expect(wantsJsonForDecoding(makeReq('application/json'))).toBe(true);
+            expect(wantsJsonForDecoding(makeReq('application/cbor'))).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Coverage rotation added focused Jest coverage for content negotiation helpers and MPT root route registration/query guards.

Verify: npm test passed (55 unit suites / 614 unit tests and 8 e2e suites / 65 e2e tests).