### PR TITLE
fix(scanner): contain self-hosted bootstrap failures

### DIFF
--- a/lambdas/scanner.bootstrap.test.ts
+++ b/lambdas/scanner.bootstrap.test.ts
@@ -1,7 +1,14 @@
+const ORIGINAL_ENV = { ...process.env };
+
 describe('Scanner lambda bootstrap', () => {
     beforeEach(() => {
         jest.resetModules();
         jest.clearAllMocks();
+        process.env = { ...ORIGINAL_ENV };
+    });
+
+    afterAll(() => {
+        process.env = ORIGINAL_ENV;
     });
 
     it('hydrates before loading scanner app exports', async () => {
@@ -49,5 +56,55 @@ describe('Scanner lambda bootstrap', () => {
         await expect(scannerModule.Internal.checkRollback({ currentSlot: 1 } as any)).resolves.toEqual(rollbackResult);
         expect(appLoaded).toBe(true);
         expect(hydrateKmsEnvironment).toHaveBeenCalledTimes(2);
+    });
+
+    it('turns self-hosted function-url bootstrap failures into 500 responses', async () => {
+        process.env.KORA_SCANNER_DEFER_IMPORTS = 'true';
+        const hydrateKmsEnvironment = jest.fn().mockResolvedValue([]);
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        jest.doMock('@koralabs/kora-labs-common/aws', () => ({ hydrateKmsEnvironment }));
+        jest.doMock('./scanner.app', () => {
+            throw new Error('scanner import boom');
+        });
+
+        let scannerModule: any;
+        await jest.isolateModulesAsync(async () => {
+            scannerModule = await import('./scanner');
+        });
+
+        try {
+            await expect(scannerModule.lambdaHandler({ requestContext: { http: {} } } as any, {} as any)).resolves.toEqual({
+                isBase64Encoded: false,
+                statusCode: 500,
+                headers: {
+                    'content-type': 'application/json'
+                },
+                body: JSON.stringify({ message: 'Scanner bootstrap failed' })
+            });
+            expect(hydrateKmsEnvironment).toHaveBeenCalledTimes(1);
+            expect(consoleError).toHaveBeenCalledTimes(1);
+            expect(consoleError.mock.calls[0][0]).toContain('scannerLambda.bootstrapFailure');
+            expect(consoleError.mock.calls[0][0]).toContain('scanner import boom');
+        } finally {
+            consoleError.mockRestore();
+        }
+    });
+
+    it('keeps throwing bootstrap failures outside self-hosted scanner runtime', async () => {
+        const hydrateKmsEnvironment = jest.fn().mockResolvedValue([]);
+
+        jest.doMock('@koralabs/kora-labs-common/aws', () => ({ hydrateKmsEnvironment }));
+        jest.doMock('./scanner.app', () => {
+            throw new Error('scanner import boom');
+        });
+
+        let scannerModule: any;
+        await jest.isolateModulesAsync(async () => {
+            scannerModule = await import('./scanner');
+        });
+
+        await expect(scannerModule.lambdaHandler({ requestContext: { http: {} } } as any, {} as any)).rejects.toThrow('scanner import boom');
+        expect(hydrateKmsEnvironment).toHaveBeenCalledTimes(1);
     });
 });

--- a/lambdas/scanner.ts
+++ b/lambdas/scanner.ts
@@ -2,11 +2,51 @@ import { hydrateKmsEnvironment } from '@koralabs/kora-labs-common/aws';
 
 type ScannerApp = typeof import('./scanner.app');
 
-export const lambdaHandler = async (event: any, context: any) => {
+const isSelfHostedScannerRuntime = () => {
+    const kmsDisabled = `${process.env.KORA_KMS_DISABLED ?? ''}`.toLowerCase();
+    return process.env.KORA_SCANNER_DEFER_IMPORTS?.toLowerCase() === 'true' || kmsDisabled === 'true' || kmsDisabled === '1';
+};
+
+const isFunctionUrlEvent = (event: any): boolean => Boolean(event?.requestContext?.http);
+
+const logScannerBootstrapFailure = (error: unknown) => {
+    const message = error instanceof Error ? error.message : `${error}`;
+    const stack = error instanceof Error ? error.stack : undefined;
+    console.error(JSON.stringify({
+        category: 'ERROR',
+        event: 'scannerLambda.bootstrapFailure',
+        message: `Scanner bootstrap failed: ${message}`,
+        stack
+    }));
+};
+
+const buildScannerBootstrapFailureResponse = (event: any) => {
+    if (!isFunctionUrlEvent(event)) return undefined;
+    return {
+        isBase64Encoded: false,
+        statusCode: 500,
+        headers: {
+            'content-type': 'application/json'
+        },
+        body: JSON.stringify({ message: 'Scanner bootstrap failed' })
+    };
+};
+
+const runScannerEntrypoint = async <T>(event: any, run: () => Promise<T>) => {
+    try {
+        return await run();
+    } catch (error) {
+        if (!isSelfHostedScannerRuntime()) throw error;
+        logScannerBootstrapFailure(error);
+        return buildScannerBootstrapFailureResponse(event);
+    }
+};
+
+export const lambdaHandler = async (event: any, context: any) => runScannerEntrypoint(event, async () => {
     await hydrateKmsEnvironment();
     const { lambdaHandler: scannerLambdaHandler } = await import('./scanner.app');
     return scannerLambdaHandler(event, context);
-};
+});
 
 export const Internal = {
     checkRollback: async (...args: Parameters<ScannerApp['Internal']['checkRollback']>) => {


### PR DESCRIPTION
Scanner bootstrap now catches self-hosted startup/import failures, logs scannerLambda.bootstrapFailure, and returns a 500 response for function-url invocations instead of letting fnserver surface startup 502s. Verify: npm test passed (55 unit suites / 627 tests and 8 e2e suites / 65 tests).