### PR TITLE
Defer scanner app dependency construction

### DIFF
--- a/lambdas/scanner.app.ts
+++ b/lambdas/scanner.app.ts
@@ -10,9 +10,33 @@ import { discoverHandleTxsBySlotRange, isMaestroConfigured, MaestroDiscoveryResu
 import { blockfrostApiCall, buildUTxOsFromKoiosTxs, defaultKoiosSettings, fetchBlockfrostDatumCbor, fetchBlockfrostTxHashes, fetchBlockfrostTxInfo, fetchKoios, fetchPaginatedResults } from '../utils/helpers';
 import { buildAndStoreMptRootHash, getChainMintingDataRootHash } from '../utils/snapshotVerification';
 
-const store = getHandlesStore();
-const handlesRepo = new HandlesRepository(store);
+type ScannerStore = ReturnType<typeof getHandlesStore>;
+
+let storeInstance: ScannerStore | undefined;
+let handlesRepoInstance: HandlesRepository | undefined;
 let initialized = false;
+
+const getStore = (): ScannerStore => {
+    if (!storeInstance) storeInstance = getHandlesStore();
+    return storeInstance;
+};
+
+const getHandlesRepo = (): HandlesRepository => {
+    if (!handlesRepoInstance) handlesRepoInstance = new HandlesRepository(getStore());
+    return handlesRepoInstance;
+};
+
+const createLazyProxy = <T extends object>(factory: () => T): T => new Proxy({} as T, {
+    get: (_target, property) => {
+        const instance = factory();
+        const value = Reflect.get(instance, property, instance);
+        return typeof value === 'function' ? value.bind(instance) : value;
+    },
+    set: (_target, property, value) => Reflect.set(factory(), property, value)
+});
+
+const store = createLazyProxy(getStore);
+const handlesRepo = createLazyProxy(getHandlesRepo);
 
 const SCANNER_LEASE_KEY = getApiScannerLeaseKey();
 const SCANNER_RECOVERY_KEY = getApiScannerRecoveryKey();

--- a/lambdas/scanner.bootstrap.test.ts
+++ b/lambdas/scanner.bootstrap.test.ts
@@ -1,3 +1,5 @@
+export {};
+
 const ORIGINAL_ENV = { ...process.env };
 
 describe('Scanner lambda bootstrap', () => {

--- a/lambdas/scanner.test.ts
+++ b/lambdas/scanner.test.ts
@@ -206,6 +206,15 @@ const setup = ({ whitelistedApiKeys = 'allowed-key' }: { whitelistedApiKeys?: st
 };
 
 describe('Scanner lambda unit tests', () => {
+    it('does not construct scanner dependencies while importing scanner app', () => {
+        jest.isolateModules(() => {
+            require('./scanner.app');
+        });
+
+        expect(getHandlesStore).not.toHaveBeenCalled();
+        expect(MockedRepoClass).not.toHaveBeenCalled();
+    });
+
     beforeEach(() => {
         jest.clearAllMocks();
     });


### PR DESCRIPTION
Defers scanner.app Redis store/repository construction until scanner runtime handlers actually use them, reducing cold-start/import-time crash surface for mainnet/scanner. Also marks scanner.bootstrap.test.ts as a module so its ORIGINAL_ENV test helper does not collide during full Jest compilation. Verify: npm test passed.