### PR TITLE
Add focused utility coverage

### DIFF
--- a/utils/deprecated.test.ts
+++ b/utils/deprecated.test.ts
@@ -1,0 +1,56 @@
+import deprecated from './deprecated';
+
+type MockResponse = {
+    set: jest.Mock<MockResponse, [string, string]>;
+    get: jest.Mock<string | undefined, [string]>;
+};
+
+const makeResponse = (initialHeaders: Record<string, string> = {}): MockResponse => {
+    const headers = new Map<string, string>(Object.entries(initialHeaders));
+    const res = {} as MockResponse;
+    res.set = jest.fn((name: string, value: string) => {
+        headers.set(name, value);
+        return res;
+    });
+    res.get = jest.fn((name: string) => headers.get(name));
+    return res;
+};
+
+describe('deprecated middleware', () => {
+    it('sets the Deprecation header and continues the middleware chain', () => {
+        const req = {} as any;
+        const res = makeResponse();
+        const next = jest.fn();
+
+        deprecated()(req, res as any, next);
+
+        expect(res.set).toHaveBeenCalledWith('Deprecation', 'true');
+        expect(res.set).not.toHaveBeenCalledWith('Link', expect.any(String));
+        expect(next).toHaveBeenCalledWith();
+    });
+
+    it('adds a successor-version link when a replacement path is supplied', () => {
+        const req = { params: { handle: 'alice' } } as any;
+        const res = makeResponse();
+        const next = jest.fn();
+
+        deprecated((request) => `/handles/${request.params.handle}/utxo`)(req, res as any, next);
+
+        expect(res.set).toHaveBeenCalledWith('Deprecation', 'true');
+        expect(res.set).toHaveBeenCalledWith('Link', '</handles/alice/utxo>; rel="successor-version"');
+        expect(next).toHaveBeenCalledWith();
+    });
+
+    it('appends successor-version links without overwriting existing Link headers', () => {
+        const req = { params: { handle: 'alice' } } as any;
+        const res = makeResponse({ Link: '<https://api.handle.me/>; rel="describedby"' });
+        const next = jest.fn();
+
+        deprecated((request) => `/handles/${request.params.handle}/datum`)(req, res as any, next);
+
+        expect(res.set).toHaveBeenCalledWith(
+            'Link',
+            '<https://api.handle.me/>; rel="describedby", </handles/alice/datum>; rel="successor-version"'
+        );
+    });
+});

--- a/utils/policies.test.ts
+++ b/utils/policies.test.ts
@@ -1,0 +1,91 @@
+import * as cbor from '@koralabs/kora-labs-common/utils/cbor';
+import { decodePoliciesDatum, normalizePolicies } from './policies';
+
+jest.mock('@koralabs/kora-labs-common/utils/cbor', () => ({
+    decodeCborToJson: jest.fn()
+}));
+
+describe('policies utilities', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('normalizes tuple policy settings and strips hex prefixes', () => {
+        expect(normalizePolicies({
+            '0xf0ff': [47931333, 0, -1],
+            '0X6C32': ['151974982', '170000000', '180000000']
+        })).toEqual({
+            f0ff: {
+                first_minting_slot: 47931333,
+                last_minting_slot: null,
+                sunset_slot: null
+            },
+            '6C32': {
+                first_minting_slot: 151974982,
+                last_minting_slot: 170000000,
+                sunset_slot: 180000000
+            }
+        });
+    });
+
+    it('normalizes object policy settings with snake case and camel case keys', () => {
+        expect(normalizePolicies({
+            f0ff: {
+                first_minting_slot: 10,
+                last_minting_slot: 20,
+                sunset_slot: 0
+            },
+            abcd: {
+                firstMintingSlot: '30',
+                lastMintingSlot: '0',
+                sunsetSlot: '40'
+            }
+        })).toEqual({
+            f0ff: {
+                first_minting_slot: 10,
+                last_minting_slot: 20,
+                sunset_slot: null
+            },
+            abcd: {
+                first_minting_slot: 30,
+                last_minting_slot: null,
+                sunset_slot: 40
+            }
+        });
+    });
+
+    it('accepts array-wrapped datum maps', () => {
+        expect(normalizePolicies([{ f0ff: [1, 0, 2] }])).toEqual({
+            f0ff: {
+                first_minting_slot: 1,
+                last_minting_slot: null,
+                sunset_slot: 2
+            }
+        });
+    });
+
+    it('rejects malformed policy datum shapes', () => {
+        expect(() => normalizePolicies(null)).toThrow('Invalid policies datum format');
+        expect(() => normalizePolicies([])).toThrow('Invalid policies datum format');
+        expect(() => normalizePolicies({ f0ff: [1, 2] })).toThrow('Invalid policy tuple format');
+        expect(() => normalizePolicies({ f0ff: ['not-a-number', 0, 0] })).toThrow('Invalid policy settings format');
+        expect(() => normalizePolicies({ f0ff: true })).toThrow('Invalid policy settings format');
+    });
+
+    it('decodes policy CBOR as hex-keyed data before normalizing', async () => {
+        jest.mocked(cbor.decodeCborToJson).mockResolvedValue({ '0xf0ff': [47931333, 0, 0] } as any);
+
+        await expect(decodePoliciesDatum('d87980')).resolves.toEqual({
+            f0ff: {
+                first_minting_slot: 47931333,
+                last_minting_slot: null,
+                sunset_slot: null
+            }
+        });
+        expect(cbor.decodeCborToJson).toHaveBeenCalledWith({
+            cborString: 'd87980',
+            schema: {},
+            defaultKeyType: 'hex'
+        });
+    });
+});

--- a/utils/verifiedSnapshot.test.ts
+++ b/utils/verifiedSnapshot.test.ts
@@ -1,0 +1,38 @@
+import { NETWORK } from '@koralabs/kora-labs-common';
+import { isChainVerifiedSnapshot, VerifiedHandleFileContent } from './verifiedSnapshot';
+
+const CURRENT_NETWORK = NETWORK.toLowerCase() || 'preview';
+
+const makeSnapshot = (verification: Partial<VerifiedHandleFileContent['verification']> = {}): VerifiedHandleFileContent => ({
+    verification: {
+        verifiedAgainstChain: true,
+        snapshotMptRootHash: 'abc123',
+        chainMptRootHash: 'abc123',
+        network: CURRENT_NETWORK,
+        verifiedAtUtc: '2026-07-26T00:00:00.000Z',
+        ...verification
+    }
+} as VerifiedHandleFileContent);
+
+describe('verifiedSnapshot utilities', () => {
+    it('accepts snapshots verified against the current chain root and network', () => {
+        expect(isChainVerifiedSnapshot(makeSnapshot())).toBe(true);
+    });
+
+    it('rejects snapshots without verification metadata', () => {
+        expect(isChainVerifiedSnapshot({} as VerifiedHandleFileContent)).toBe(false);
+    });
+
+    it('rejects snapshots that were not verified against chain', () => {
+        expect(isChainVerifiedSnapshot(makeSnapshot({ verifiedAgainstChain: false }))).toBe(false);
+    });
+
+    it('rejects snapshots when the stored snapshot root differs from chain', () => {
+        expect(isChainVerifiedSnapshot(makeSnapshot({ chainMptRootHash: 'different-root' }))).toBe(false);
+    });
+
+    it('rejects snapshots from a different network', () => {
+        expect(isChainVerifiedSnapshot(makeSnapshot({ network: 'mainnet' }))).toBe(CURRENT_NETWORK === 'mainnet');
+        expect(isChainVerifiedSnapshot(makeSnapshot({ network: 'definitely-not-current-network' }))).toBe(false);
+    });
+});


### PR DESCRIPTION
Coverage rotation: added focused unit coverage for policy datum normalization/CBOR decode wiring, verified snapshot acceptance/rejection, and deprecated middleware header behavior.

Verify: npm test passed on 2026-07-26; 60 unit suites and 8 e2e suites passed.