### PR TITLE
chore: rotate vulnerable npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "handles-public-api",
-    "version": "1.14.2",
+    "version": "1.14.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "handles-public-api",
-            "version": "1.14.2",
+            "version": "1.14.3",
             "license": "Mozilla Public License 2.0",
             "dependencies": {
                 "@aiken-lang/merkle-patricia-forestry": "^1.3.1",
@@ -4807,9 +4807,9 @@
             "license": "MIT"
         },
         "node_modules/body-parser": {
-            "version": "1.20.5",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+            "version": "1.20.6",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+            "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
             "license": "MIT",
             "dependencies": {
                 "bytes": "~3.1.2",
@@ -4859,16 +4859,16 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -7671,9 +7671,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
-            "integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+            "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
             "dev": true,
             "funding": [
                 {
@@ -8661,9 +8661,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.6.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-            "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+            "version": "7.6.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+            "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "handles-public-api",
-    "version": "1.14.2",
+    "version": "1.14.3",
     "description": "A downloadable and containerized decentralized API for Handles",
     "main": "index.js",
     "repository": "https://github.com/koralabs/handles-public-api.git",
@@ -28,11 +28,13 @@
         "lodash": "4.18.1",
         "qs": "6.15.2",
         "minimatch": "10.2.5",
-        "protobufjs": "7.6.4",
+        "protobufjs": "7.6.5",
         "@protobufjs/utf8": "1.1.1",
         "path-to-regexp": "0.1.13",
         "picomatch": "2.3.2",
-        "js-yaml": "5.2.0"
+        "js-yaml": "5.2.2",
+        "body-parser": "1.20.6",
+        "brace-expansion": "5.0.8"
     },
     "dependencies": {
         "@aiken-lang/merkle-patricia-forestry": "^1.3.1",


### PR DESCRIPTION
Rotates vulnerable npm dependency overrides and bumps handles-public-api to 1.14.3.

Validation:
- npm install
- npm run build:lambda
- npm test
- npm audit --json (0 vulnerabilities)

No upstream-blocked advisories.