### PR TITLE
Defer scanner AWS bootstrap import

### DIFF
--- a/lambdas/scanner.bootstrap.test.ts
+++ b/lambdas/scanner.bootstrap.test.ts
@@ -93,6 +93,45 @@ describe('Scanner lambda bootstrap', () => {
         }
     });
 
+    it('turns self-hosted function-url aws import failures into 500 responses', async () => {
+        process.env.KORA_SCANNER_DEFER_IMPORTS = 'true';
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        jest.doMock('@koralabs/kora-labs-common/aws', () => {
+            throw new Error('aws import boom');
+        });
+        jest.doMock('./scanner.app', () => ({
+            lambdaHandler: jest.fn(),
+            Internal: {
+                checkRollback: jest.fn(),
+                processRollback: jest.fn(),
+                processReindex: jest.fn(),
+                scan: jest.fn()
+            }
+        }));
+
+        let scannerModule: any;
+        await jest.isolateModulesAsync(async () => {
+            scannerModule = await import('./scanner');
+        });
+
+        try {
+            await expect(scannerModule.lambdaHandler({ requestContext: { http: {} } } as any, {} as any)).resolves.toEqual({
+                isBase64Encoded: false,
+                statusCode: 500,
+                headers: {
+                    'content-type': 'application/json'
+                },
+                body: JSON.stringify({ message: 'Scanner bootstrap failed' })
+            });
+            expect(consoleError).toHaveBeenCalledTimes(1);
+            expect(consoleError.mock.calls[0][0]).toContain('scannerLambda.bootstrapFailure');
+            expect(consoleError.mock.calls[0][0]).toContain('aws import boom');
+        } finally {
+            consoleError.mockRestore();
+        }
+    });
+
     it('keeps throwing bootstrap failures outside self-hosted scanner runtime', async () => {
         const hydrateKmsEnvironment = jest.fn().mockResolvedValue([]);
 

--- a/lambdas/scanner.ts
+++ b/lambdas/scanner.ts
@@ -1,5 +1,3 @@
-import { hydrateKmsEnvironment } from '@koralabs/kora-labs-common/aws';
-
 type ScannerApp = typeof import('./scanner.app');
 
 const isSelfHostedScannerRuntime = () => {
@@ -42,30 +40,35 @@ const runScannerEntrypoint = async <T>(event: any, run: () => Promise<T>) => {
     }
 };
 
+const hydrateScannerEnvironment = async () => {
+    const { hydrateKmsEnvironment } = await import('@koralabs/kora-labs-common/aws');
+    return hydrateKmsEnvironment();
+};
+
 export const lambdaHandler = async (event: any, context: any) => runScannerEntrypoint(event, async () => {
-    await hydrateKmsEnvironment();
+    await hydrateScannerEnvironment();
     const { lambdaHandler: scannerLambdaHandler } = await import('./scanner.app');
     return scannerLambdaHandler(event, context);
 });
 
 export const Internal = {
     checkRollback: async (...args: Parameters<ScannerApp['Internal']['checkRollback']>) => {
-        await hydrateKmsEnvironment();
+        await hydrateScannerEnvironment();
         const { Internal: scannerInternal } = await import('./scanner.app');
         return scannerInternal.checkRollback(...args);
     },
     processRollback: async (...args: Parameters<ScannerApp['Internal']['processRollback']>) => {
-        await hydrateKmsEnvironment();
+        await hydrateScannerEnvironment();
         const { Internal: scannerInternal } = await import('./scanner.app');
         return scannerInternal.processRollback(...args);
     },
     processReindex: async (...args: Parameters<ScannerApp['Internal']['processReindex']>) => {
-        await hydrateKmsEnvironment();
+        await hydrateScannerEnvironment();
         const { Internal: scannerInternal } = await import('./scanner.app');
         return scannerInternal.processReindex(...args);
     },
     scan: async (...args: Parameters<ScannerApp['Internal']['scan']>) => {
-        await hydrateKmsEnvironment();
+        await hydrateScannerEnvironment();
         const { Internal: scannerInternal } = await import('./scanner.app');
         return scannerInternal.scan(...args);
     }


### PR DESCRIPTION
Defers the scanner lambda aws helper import into the protected bootstrap path so self-hosted function-url startup failures are logged and surfaced as controlled 500 responses instead of killing module initialization. Verify: npm test passed with 60 unit suites / 647 tests and 8 e2e suites / 65 tests.