### PR TITLE
Clear npm audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "handles-public-api",
-    "version": "1.14.3",
+    "version": "1.14.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "handles-public-api",
-            "version": "1.14.3",
+            "version": "1.14.4",
             "license": "Mozilla Public License 2.0",
             "dependencies": {
                 "@aiken-lang/merkle-patricia-forestry": "^1.3.1",
@@ -4859,9 +4859,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6841,9 +6841,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+            "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -8130,9 +8130,9 @@
             "license": "ISC"
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.17",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+            "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
             "funding": [
                 {
                     "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "handles-public-api",
-    "version": "1.14.3",
+    "version": "1.14.4",
     "description": "A downloadable and containerized decentralized API for Handles",
     "main": "index.js",
     "repository": "https://github.com/koralabs/handles-public-api.git",
@@ -34,7 +34,9 @@
         "picomatch": "2.3.2",
         "js-yaml": "5.2.2",
         "body-parser": "1.20.6",
-        "brace-expansion": "5.0.8"
+        "brace-expansion": "5.0.9",
+        "ip-address": "10.3.1",
+        "nanoid": "3.3.17"
     },
     "dependencies": {
         "@aiken-lang/merkle-patricia-forestry": "^1.3.1",


### PR DESCRIPTION
Summary:
- Bumped package version to 1.14.4 for the npm vulnerability rotation.
- Updated npm overrides and lockfile to clear brace-expansion, ip-address, and nanoid advisories.

Validation:
- npm install: passed, found 0 vulnerabilities
- npm audit --json: passed, 0 vulnerabilities
- npm run build:lambda: passed
- npm test: passed, 60 unit suites and 8 e2e suites