### PR TITLE
Rotate vulnerable npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "handles-public-api",
-    "version": "1.14.4",
+    "version": "1.14.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "handles-public-api",
-            "version": "1.14.4",
+            "version": "1.14.5",
             "license": "Mozilla Public License 2.0",
             "dependencies": {
                 "@aiken-lang/merkle-patricia-forestry": "^1.3.1",
@@ -8130,9 +8130,9 @@
             "license": "ISC"
         },
         "node_modules/nanoid": {
-            "version": "3.3.17",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-            "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "handles-public-api",
-    "version": "1.14.4",
+    "version": "1.14.5",
     "description": "A downloadable and containerized decentralized API for Handles",
     "main": "index.js",
     "repository": "https://github.com/koralabs/handles-public-api.git",
@@ -36,7 +36,7 @@
         "body-parser": "1.20.6",
         "brace-expansion": "5.0.9",
         "ip-address": "10.3.1",
-        "nanoid": "3.3.17"
+        "nanoid": "3.3.18"
     },
     "dependencies": {
         "@aiken-lang/merkle-patricia-forestry": "^1.3.1",

--- a/rollup.package.json
+++ b/rollup.package.json
@@ -13,11 +13,14 @@
         "start:forever": "mkdir -p forever && nohup node express.js >> ./forever/api.log 2>&1 &",
         "forever:list": "ps -ef | grep \"node express.js\" | grep -v grep || true"
     },
+    "overrides": {
+        "body-parser": "2.3.0"
+    },
     "dependencies": {
         "@aiken-lang/merkle-patricia-forestry": "^1.3.1",
         "swagger-ui-express": "^4.5.0",
         "@valkey/valkey-glide": "^2.4.1",
         "qs": "^6.15.2",
-        "protobufjs": "^7.6.4"
+        "protobufjs": "^7.6.5"
     }
 }


### PR DESCRIPTION
Dependency vulnerability rotation for api.handle.me.

Changes:
- Bumped package version to 1.14.5.
- Updated nanoid override to 3.3.18 to clear GHSA-2v37-7h3g-55p8.
- Updated lambda bundle package metadata so dist install clears body-parser/protobufjs advisories.

Validation:
- npm install: passed
- npm audit --json: passed with 0 vulnerabilities
- npm run build:lambda: passed
- npm test: passed (61 unit suites, 8 e2e suites)