### PR TITLE
Restore deterministic API CI

### DIFF
--- a/.github/workflows/deploy-box.yml
+++ b/.github/workflows/deploy-box.yml
@@ -8,23 +8,21 @@ name: api.handle.me (box / service-fn-push, no AWS)
 # TEMPLATE for any PUBLIC repo: copy this, set the repo's FN_FUNCTIONS/build cmds, and provide the
 # vars.DEPLOY_FETCH_BASE variable + the R2_*/KORA_DEPLOY_HMAC_SECRET/DEPLOYMENT_ACCESS_TOKEN secrets.
 on:
-  # Pre-cutover: workflow_dispatch ONLY (the bring-up dispatches it) so the box deploy does not race
-  # the AWS deploy.yml. AT PREPROD CUTOVER: add `push: { branches: [preprod] }` here AND drop preprod
-  # from deploy.yml's push triggers.
+  # All environments are deployed explicitly through the self-hosted box workflow.
   workflow_dispatch:
     inputs:
       environment:
         description: Deployment environment
         required: true
         type: choice
-        options: [preprod, mainnet]
-        default: preprod
+        options: [preview, preprod, mainnet]
+        default: preview
 jobs:
   deploy-box:
     name: Box deploy (service) from ${{ github.ref_name }}
     runs-on: ubuntu-22.04
     concurrency:
-      group: deploy-box-${{ github.ref }}
+      group: deploy-box-${{ github.event.inputs.environment }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +32,7 @@ jobs:
       - name: Build (box/service) + stage to R2 + signed deploy trigger
         env:
           DEPLOYABLE: api.handle.me
-          BOX_ENV: ${{ github.event.inputs.environment || 'preprod' }}
+          BOX_ENV: ${{ github.event.inputs.environment }}
           NODE_VERSION: '22'
           SERVICE_INSTALL_CMD: npm install
           # Also stage deployment_info.json into ./dist so the /deployment endpoint can

--- a/.github/workflows/yarn-pr-tests.yml
+++ b/.github/workflows/yarn-pr-tests.yml
@@ -1,4 +1,4 @@
-name: Yarn PR Tests
+name: NPM Tests
 
 on:
   push:
@@ -10,9 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
-      - run: yarn
-      - run: yarn test
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 dotenv.config({ path: ".env" });
 
 process.env.NODE_ENV = 'test';
+process.env.IS_LOCAL = 'true';
 // Force a deterministic Maestro key for unit tests (overrides whatever the dev's .env has).
 // Tests intercept fetch so this value is never sent to a real API.
 process.env.MAESTRO_API_KEY = 'test-maestro-api-key';

--- a/jest.critical.config.ts
+++ b/jest.critical.config.ts
@@ -2,6 +2,9 @@ import dotenv from 'dotenv';
 dotenv.config({ path: '.env' });
 
 process.env.NODE_ENV = 'test';
+process.env.IS_LOCAL = 'true';
+process.env.REDIS_USE_TLS = 'false';
+process.env.ENABLE_DATUM_ENDPOINT = 'true';
 
 const config = {
     preset: 'ts-jest/presets/default-esm',

--- a/jest.e2e.config.ts
+++ b/jest.e2e.config.ts
@@ -2,6 +2,9 @@ import dotenv from 'dotenv';
 dotenv.config({ path: '.env' });
 
 process.env.NODE_ENV = 'test';
+process.env.IS_LOCAL = 'true';
+process.env.REDIS_USE_TLS = 'false';
+process.env.ENABLE_DATUM_ENDPOINT = 'true';
 
 const config = {
     preset: 'ts-jest/presets/default-esm',

--- a/repositories/tests/handles.repository.branches.test.ts
+++ b/repositories/tests/handles.repository.branches.test.ts
@@ -655,7 +655,7 @@ describe('HandlesRepository branch tests', () => {
         expect(repo.currentHttpStatus()).toBe(200);
 
         store.getMetrics.mockReturnValue({
-            lastSlot: freshCurrentSlot + 500,
+            lastSlot: freshCurrentSlot + 600,
             currentSlot: freshCurrentSlot,
             currentBlockHash: 'block',
             tipBlockHash: 'tip'

--- a/shell/entrypoint.sh
+++ b/shell/entrypoint.sh
@@ -17,9 +17,7 @@ NODE_DB=${NODE_DB:-'/db'}
 SOCKET_PATH=${SOCKET_PATH:-'/ipc/node.socket'}
 CARDANO_NODE_PATH=${CARDANO_NODE_PATH:-'./cardano-node'}
 NODE_CONFIG_PATH=${NODE_CONFIG_PATH:-"./${NETWORK}"}
-HOST=""
-NODE_CONFIG=""
-NODE_SOCKET=""
+OGMIOS_ARGS=("$@")
 OGMIOS_PID=""
 API_PID=""
 CARDANO_NODE_PID=""
@@ -58,25 +56,34 @@ function register_child {
   CHILD_PIDS+=("$1")
 }
 
+function has_argument {
+  local expected="$1"
+  shift
+  local argument
+  for argument in "$@"; do
+    if [[ "${argument}" == "${expected}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 trap 'cleanup 0' INT TERM QUIT ABRT
 
-if [[ "$@" != *"--host"* ]]
-then
-    HOST="--host 0.0.0.0"
+if ! has_argument "--host" "${OGMIOS_ARGS[@]}"; then
+    OGMIOS_ARGS+=("--host" "0.0.0.0")
 fi
-if [[ "$@" != *"--node-config"* ]]
-then
-    NODE_CONFIG="--node-config ${NODE_CONFIG_PATH}/config.json"
+if ! has_argument "--node-config" "${OGMIOS_ARGS[@]}"; then
+    OGMIOS_ARGS+=("--node-config" "${NODE_CONFIG_PATH}/config.json")
 fi
-if [[ "$@" != *"--node-socket"* ]]
-then
-    NODE_SOCKET="--node-socket ${SOCKET_PATH}"
+if ! has_argument "--node-socket" "${OGMIOS_ARGS[@]}"; then
+    OGMIOS_ARGS+=("--node-socket" "${SOCKET_PATH}")
 fi
 
 if [[ "${MODE}" == "ogmios" || "${MODE}" == "both" || "${MODE}" == "all" ]]; then
     # --include-transaction-cbor
     echo "STARTING OGMIOS..."
-    ogmios --log-level Error $HOST $NODE_CONFIG $NODE_SOCKET $@ &
+    ogmios --log-level Error "${OGMIOS_ARGS[@]}" &
     OGMIOS_PID=$!
     register_child "${OGMIOS_PID}"
     echo "  ...OGMIOS RUNNING"
@@ -84,7 +91,8 @@ fi
 
 if [[ "${MODE}" == "ogmios" || "${MODE}" == "all" || "${MODE}" == "api-only" ]]; then
     echo "STARTING API..."
-    source ${HOME:-'~'}/.nvm/nvm.sh
+    # shellcheck source=/dev/null
+    source "${HOME}/.nvm/nvm.sh"
     export TMPDIR=/tmp
     nvm use 21
     sed -i 's https://api.handle.me http://localhost:3141 ' swagger.yml
@@ -103,7 +111,8 @@ release_host() {
             echo -n "pre-release-preview";;
     esac
 }
-export RELEASE_HOST=$(release_host)
+RELEASE_HOST=$(release_host)
+export RELEASE_HOST
 
 if [[ "${MODE}" == "cardano-node" || "${MODE}" == "both" || "${MODE}" == "all" ]]; then
     echo "STARTING CARDANO-NODE..."
@@ -117,17 +126,18 @@ if [[ "${MODE}" == "cardano-node" || "${MODE}" == "both" || "${MODE}" == "all" ]
         mkdir -p "${NODE_DB}"
         echo "Grabbing latest snapshot with Mithril."
         MITHRIL_VERSION=2603.1
-        curl -fsSL https://github.com/input-output-hk/mithril/releases/download/${MITHRIL_VERSION}/mithril-${MITHRIL_VERSION}-linux-x64.tar.gz | tar -xz
-        export AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE_HOST}.api.mithril.network/aggregator
-        export GENESIS_VERIFICATION_KEY=$(curl https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE_HOST}/genesis.vkey)
-        export ANCILLARY_VERIFICATION_KEY=$(curl https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE_HOST}/ancillary.vkey)
-        export DIGEST=latest
+        curl -fsSL "https://github.com/input-output-hk/mithril/releases/download/${MITHRIL_VERSION}/mithril-${MITHRIL_VERSION}-linux-x64.tar.gz" | tar -xz
+        AGGREGATOR_ENDPOINT="https://aggregator.${RELEASE_HOST}.api.mithril.network/aggregator"
+        GENESIS_VERIFICATION_KEY=$(curl -fsS "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE_HOST}/genesis.vkey")
+        ANCILLARY_VERIFICATION_KEY=$(curl -fsS "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE_HOST}/ancillary.vkey")
+        DIGEST=latest
+        export AGGREGATOR_ENDPOINT GENESIS_VERIFICATION_KEY ANCILLARY_VERIFICATION_KEY DIGEST
         chmod +x ./mithril-client
         #curl -o - $(./mithril-client cardano-db snapshot show --json $SNAPSHOT_DIGEST | jq -r '.locations[0]') | tar --use-compress-program=unzstd -x -C ${NODE_DB}
         if [[ "${NODE_DB%db}" == "" ]]; then
-            ./mithril-client cardano-db download --include-ancillary $DIGEST
+            ./mithril-client cardano-db download --include-ancillary "$DIGEST"
         else
-            ./mithril-client cardano-db download --download-dir "${NODE_DB%db}" --include-ancillary $DIGEST
+            ./mithril-client cardano-db download --download-dir "${NODE_DB%db}" --include-ancillary "$DIGEST"
         fi
         echo "Mithril snapshot downloaded and validated."
     fi
@@ -135,25 +145,25 @@ if [[ "${MODE}" == "cardano-node" || "${MODE}" == "both" || "${MODE}" == "all" ]
     echo "Starting cardano-node."
 
     # Workaround for Mithril not outputting the protocolMagicId
-    cat ${NODE_CONFIG_PATH}/shelley-genesis.json | jq -r .networkMagic > ${NODE_DB}/protocolMagicId
+    jq -r .networkMagic "${NODE_CONFIG_PATH}/shelley-genesis.json" > "${NODE_DB}/protocolMagicId"
 
-    ${CARDANO_NODE_PATH} run \
-        --config ${NODE_CONFIG_PATH}/config.json \
-        --topology ${NODE_CONFIG_PATH}/topology.json \
-        --database-path ${NODE_DB} \
+    "${CARDANO_NODE_PATH}" run \
+        --config "${NODE_CONFIG_PATH}"/config.json \
+        --topology "${NODE_CONFIG_PATH}"/topology.json \
+        --database-path "${NODE_DB}" \
         --port 3000 \
         --host-addr 0.0.0.0 \
-        --socket-path ${SOCKET_PATH} &
+        --socket-path "${SOCKET_PATH}" &
     CARDANO_NODE_PID=$!
     register_child "${CARDANO_NODE_PID}"
 
     if [[ "${ENABLE_SOCKET_REDIRECT}" == "true" ]]; then
-        until [ -S ${SOCKET_PATH} ]
+        until [ -S "${SOCKET_PATH}" ]
         do
             sleep 1
         done
         echo "Found! ${SOCKET_PATH}"
-        socat TCP-LISTEN:4001,reuseaddr,fork UNIX-CONNECT:${SOCKET_PATH} &
+        socat TCP-LISTEN:4001,reuseaddr,fork UNIX-CONNECT:"${SOCKET_PATH}" &
         SOCAT_PID=$!
         register_child "${SOCAT_PID}"
     fi

--- a/shell/install.sh
+++ b/shell/install.sh
@@ -16,31 +16,32 @@ ${SUDO} apt install -y git curl socat jq unzip tini lz4 zstd valkey
 if command -v systemctl >/dev/null 2>&1; then
     ${SUDO} systemctl enable valkey-server || true
 fi
-curl -fsSL https://github.com/IntersectMBO/cardano-node/releases/download/${CARDANO_NODE_VER}/cardano-node-${CARDANO_NODE_VER}-linux.tar.gz | tar -xz
+curl -fsSL "https://github.com/IntersectMBO/cardano-node/releases/download/${CARDANO_NODE_VER}/cardano-node-${CARDANO_NODE_VER}-linux.tar.gz" | tar -xz
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-rm -f ./cardano-node-${CARDANO_NODE_VER}-linux.tar.gz
+rm -f ./cardano-node-"${CARDANO_NODE_VER}"-linux.tar.gz
 cp ./bin/* ./
-chmod +x ./cardano-node && chmod +x ./entrypoint.sh && mkdir -p $(dirname "${SOCKET_PATH}") && mkdir -p handles && touch handles/handles.json
+chmod +x ./cardano-node && chmod +x ./entrypoint.sh && mkdir -p "$(dirname "${SOCKET_PATH}")" && mkdir -p handles && touch handles/handles.json
 BASE_URL=${CONFIG_FILES_BASE_URL}
 declare -a NETWORKS=(preview preprod mainnet)
 declare -a ERAS=(byron shelley alonzo conway)
 for net in "${NETWORKS[@]}"
 do 
-    mkdir -p ${net}
-    if [ ${net} == "mainnet" ]; then
-        curl -sL ${BASE_URL}/${net}/checkpoints.json -o ${net}/checkpoints.json
+    mkdir -p "${net}"
+    if [ "${net}" == "mainnet" ]; then
+        curl -sL "${BASE_URL}"/"${net}"/checkpoints.json -o "${net}"/checkpoints.json
     fi
-    curl -sL ${BASE_URL}/${net}/config.json -o ${net}/config.json
-    curl -sL ${BASE_URL}/${net}/topology.json -o ${net}/topology.json
+    curl -sL "${BASE_URL}"/"${net}"/config.json -o "${net}"/config.json
+    curl -sL "${BASE_URL}"/"${net}"/topology.json -o "${net}"/topology.json
     for era in "${ERAS[@]}"
     do
-        curl -sL ${BASE_URL}/${net}/${era}-genesis.json -o ${net}/${era}-genesis.json
+        curl -sL "${BASE_URL}"/"${net}"/"${era}"-genesis.json -o "${net}"/"${era}"-genesis.json
     done
 done
-curl -sL https://github.com/CardanoSolutions/ogmios/releases/download/v${OGMIOS_VER}/ogmios-v${OGMIOS_VER}-x86_64-linux.zip -o ogmios.zip
+curl -sL "https://github.com/CardanoSolutions/ogmios/releases/download/v${OGMIOS_VER}/ogmios-v${OGMIOS_VER}-x86_64-linux.zip" -o ogmios.zip
 unzip ogmios.zip -d ./ogmios-install && rm ogmios.zip
 ${SUDO} cp ./ogmios-install/bin/ogmios /bin/ogmios && ${SUDO} chmod +x /bin/ogmios && rm -rf ./ogmios-install
-source ~/.nvm/nvm.sh
+# shellcheck source=/dev/null
+source "${HOME}/.nvm/nvm.sh"
 export TMPDIR=/tmp
 nvm install 21
 nvm use 21

--- a/shell/local_valkey.sh
+++ b/shell/local_valkey.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eu
+# shellcheck source=/dev/null
 set -a && source .env && set +a
 REDIS_PORT=${REDIS_PORT:-6380}
 REDIS_HOST=${REDIS_HOST:-127.0.0.1}

--- a/shell/reindex-scanner.sh
+++ b/shell/reindex-scanner.sh
@@ -26,7 +26,7 @@ get_route53_set_identifier() {
     local env_key="$1"
     local suffix="${env_key#API_SCANNER_FUNCTION_URL_}"
     local alias_upper="${suffix##*_}"
-    local region_token="${suffix%_${alias_upper}}"
+    local region_token="${suffix%_"${alias_upper}"}"
     local region_name=""
     if [[ "$region_token" == *"EAST"* ]]; then
         region_name="east"

--- a/shell/start_local.sh
+++ b/shell/start_local.sh
@@ -8,6 +8,7 @@ CARDANO_NODE_PORT_OVERRIDE="${CARDANO_NODE_PORT-}"
 BASE_URL_OVERRIDE="${CONFIG_FILES_BASE_URL-}"
 CARDANO_DB_PATH_OVERRIDE="${CARDANO_DB_PATH-}"
 
+# shellcheck source=/dev/null
 set -a && source .env && set +a
 if [[ -n "${NETWORK_OVERRIDE}" ]]; then export NETWORK="${NETWORK_OVERRIDE}"; fi
 if [[ -n "${SOCKET_PATH_OVERRIDE}" ]]; then export SOCKET_PATH="${SOCKET_PATH_OVERRIDE}"; fi
@@ -28,10 +29,7 @@ CARDANO_NODE_PID=""
 OGMIOS_PID=""
 MANAGED_CARDANO_NODE=false
 MANAGED_OGMIOS=false
-HOST=""
-NODE_CONFIG=""
-NODE_SOCKET=""
-OGMIOS_PORT_ARG=""
+OGMIOS_ARGS=("$@")
 
 cleanup() {
     if [[ "${MANAGED_CARDANO_NODE}" == "true" ]] && [[ -n "${CARDANO_NODE_PID}" ]] && kill -0 "${CARDANO_NODE_PID}" 2>/dev/null; then
@@ -51,23 +49,31 @@ cleanup() {
     exit 0
 }
 
+has_argument() {
+    local expected="$1"
+    shift
+    local argument
+    for argument in "$@"; do
+        if [[ "${argument}" == "${expected}" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 trap cleanup INT TERM QUIT ABRT
 
-if [[ "$@" != *"--host"* ]]
-then
-    HOST="--host 0.0.0.0"
+if ! has_argument "--host" "${OGMIOS_ARGS[@]}"; then
+    OGMIOS_ARGS+=("--host" "0.0.0.0")
 fi
-if [[ "$@" != *"--node-config"* ]]
-then
-    NODE_CONFIG="--node-config ${NODE_CONFIG_PATH}/config.json"
+if ! has_argument "--node-config" "${OGMIOS_ARGS[@]}"; then
+    OGMIOS_ARGS+=("--node-config" "${NODE_CONFIG_PATH}/config.json")
 fi
-if [[ "$@" != *"--node-socket"* ]]
-then
-    NODE_SOCKET="--node-socket ${SOCKET_PATH}"
+if ! has_argument "--node-socket" "${OGMIOS_ARGS[@]}"; then
+    OGMIOS_ARGS+=("--node-socket" "${SOCKET_PATH}")
 fi
-if [[ "$@" != *"--port"* ]]
-then
-    OGMIOS_PORT_ARG="--port ${OGMIOS_PORT}"
+if ! has_argument "--port" "${OGMIOS_ARGS[@]}"; then
+    OGMIOS_ARGS+=("--port" "${OGMIOS_PORT}")
 fi
 
 find_pid_by_arg() {
@@ -84,7 +90,7 @@ find_pid_by_arg() {
     echo -n "${match}"
 }
 
-mkdir -p  $HOME/.local/bin
+mkdir -p  "$HOME"/.local/bin
 
 if [ -d "../api.handle.me/workers" ] && [ "$(realpath ../api.handle.me/workers)" != "$(realpath ./workers)" ]; then
     cp ../api.handle.me/workers/* ./workers/ 
@@ -114,17 +120,17 @@ declare -a NETWORKS=(preview preprod mainnet)
 declare -a ERAS=(byron shelley alonzo conway)
 for net in "${NETWORKS[@]}"; \
 do \
-    mkdir -p tmp/${net}
-    curl -sL ${BASE_URL}/${net}/config.json -o tmp/${net}/config.json
-    curl -sL ${BASE_URL}/${net}/topology.json -o tmp/${net}/topology.json
-    curl -sL ${BASE_URL}/${net}/peer-snapshot.json -o tmp/${net}/peer-snapshot.json
-    curl -sL ${BASE_URL}/${net}/checkpoints.json -o tmp/${net}/checkpoints.json
+    mkdir -p tmp/"${net}"
+    curl -sL "${BASE_URL}"/"${net}"/config.json -o tmp/"${net}"/config.json
+    curl -sL "${BASE_URL}"/"${net}"/topology.json -o tmp/"${net}"/topology.json
+    curl -sL "${BASE_URL}"/"${net}"/peer-snapshot.json -o tmp/"${net}"/peer-snapshot.json
+    curl -sL "${BASE_URL}"/"${net}"/checkpoints.json -o tmp/"${net}"/checkpoints.json
     for era in "${ERAS[@]}"; \
     do \
-        curl -sL ${BASE_URL}/${net}/${era}-genesis.json -o tmp/${net}/${era}-genesis.json; \
+        curl -sL "${BASE_URL}"/"${net}"/"${era}"-genesis.json -o tmp/"${net}"/"${era}"-genesis.json; \
     done; \
-    jq '.EnableP2P = true | .PeerSharing = true' tmp/${net}/config.json > tmp/${net}/config.p2p.json
-    mv tmp/${net}/config.p2p.json tmp/${net}/config.json
+    jq '.EnableP2P = true | .PeerSharing = true' tmp/"${net}"/config.json > tmp/"${net}"/config.p2p.json
+    mv tmp/"${net}"/config.p2p.json tmp/"${net}"/config.json
 done
 
 release_host() {
@@ -135,29 +141,31 @@ release_host() {
             echo -n "pre-release-preview";;
     esac
 }
-export RELEASE_HOST=$(release_host)
+RELEASE_HOST=$(release_host)
+export RELEASE_HOST
 
 NODE_DB="${CARDANO_DB_PATH}/${NETWORK}/db"
 
 if [[ -d "${NODE_DB}/immutable" ]]; then
     echo "Previous Cardano database found. Continuing scan"
 else
-    rm -rf ${NODE_DB}
-    mkdir -p ${NODE_DB}
+    rm -rf "${NODE_DB}"
+    mkdir -p "${NODE_DB}"
     mkdir -p ./tmp/mithril
     echo "Grabbing latest snapshot with Mithril."
     MITHRIL_VERSION=2603.1
-    (cd ./tmp/mithril && curl -fsSL https://github.com/input-output-hk/mithril/releases/download/${MITHRIL_VERSION}/mithril-${MITHRIL_VERSION}-linux-x64.tar.gz | tar -xz)
-    export AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE_HOST}.api.mithril.network/aggregator
-    export GENESIS_VERIFICATION_KEY=$(curl https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE_HOST}/genesis.vkey)
-    export ANCILLARY_VERIFICATION_KEY=$(curl https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE_HOST}/ancillary.vkey)
-    export DIGEST=latest
+    (cd ./tmp/mithril && curl -fsSL "https://github.com/input-output-hk/mithril/releases/download/${MITHRIL_VERSION}/mithril-${MITHRIL_VERSION}-linux-x64.tar.gz" | tar -xz)
+    AGGREGATOR_ENDPOINT="https://aggregator.${RELEASE_HOST}.api.mithril.network/aggregator"
+    GENESIS_VERIFICATION_KEY=$(curl -fsS "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE_HOST}/genesis.vkey")
+    ANCILLARY_VERIFICATION_KEY=$(curl -fsS "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE_HOST}/ancillary.vkey")
+    DIGEST=latest
+    export AGGREGATOR_ENDPOINT GENESIS_VERIFICATION_KEY ANCILLARY_VERIFICATION_KEY DIGEST
     chmod +x ./tmp/mithril/mithril-client
     #curl -o - $(./mithril-client cardano-db snapshot show --json $SNAPSHOT_DIGEST | jq -r '.locations[0]') | tar --use-compress-program=unzstd -x -C ${NODE_DB}
     if [[ "${NODE_DB%db}" == "" ]]; then
-        ./tmp/mithril/mithril-client cardano-db download --include-ancillary $DIGEST
+        ./tmp/mithril/mithril-client cardano-db download --include-ancillary "$DIGEST"
     else
-        ./tmp/mithril/mithril-client cardano-db download --download-dir "${NODE_DB%db}" --include-ancillary $DIGEST
+        ./tmp/mithril/mithril-client cardano-db download --download-dir "${NODE_DB%db}" --include-ancillary "$DIGEST"
     fi
     echo "Mithril snapshot downloaded and validated."
 fi
@@ -171,12 +179,12 @@ if [ ! -x ./tmp/cardano-node/bin/cardano-node ] || [ "${INSTALLED_CARDANO_NODE_V
     echo "Installing cardano-node ${CARDANO_NODE_VER}..."
     rm -rf ./tmp/cardano-node
     mkdir -p ./tmp/cardano-node
-    (cd ./tmp/cardano-node && curl -fsSL https://github.com/IntersectMBO/cardano-node/releases/download/${CARDANO_NODE_VER}/cardano-node-${CARDANO_NODE_VER}-linux-amd64.tar.gz | tar -xz)
+    (cd ./tmp/cardano-node && curl -fsSL https://github.com/IntersectMBO/cardano-node/releases/download/"${CARDANO_NODE_VER}"/cardano-node-"${CARDANO_NODE_VER}"-linux-amd64.tar.gz | tar -xz)
     chmod +x ./tmp/cardano-node/bin/cardano-node
 fi
 
 # Workaround for Mithril not outputting the protocolMagicId
-cat ${NODE_CONFIG_PATH}/shelley-genesis.json | jq -r .networkMagic > ${NODE_DB}/protocolMagicId
+jq -r .networkMagic "${NODE_CONFIG_PATH}/shelley-genesis.json" > "${NODE_DB}/protocolMagicId"
 
 CARDANO_NODE_PID="$(find_pid_by_arg "cardano-node" "--socket-path ${SOCKET_PATH}")"
 if [[ -n "${CARDANO_NODE_PID}" ]] && kill -0 "${CARDANO_NODE_PID}" 2>/dev/null
@@ -191,12 +199,12 @@ then
     echo "cardano-node already running. Reusing PID ${CARDANO_NODE_PID}."
 else
     ./tmp/cardano-node/bin/cardano-node run \
-        --config ${NODE_CONFIG_PATH}/config.json \
-        --topology ${NODE_CONFIG_PATH}/topology.json \
-        --database-path ${NODE_DB} \
-        --port ${CARDANO_NODE_PORT} \
+        --config "${NODE_CONFIG_PATH}"/config.json \
+        --topology "${NODE_CONFIG_PATH}"/topology.json \
+        --database-path "${NODE_DB}" \
+        --port "${CARDANO_NODE_PORT}" \
         --host-addr 0.0.0.0 \
-        --socket-path ${SOCKET_PATH} > >(stdbuf -oL -eL egrep --line-buffered '\b(startup:Info:|local socket:|ChainDB:Notice:|:Critical:|Validating chunk)\b') 2>&1 &
+        --socket-path "${SOCKET_PATH}" > >(stdbuf -oL -eL egrep --line-buffered '\b(startup:Info:|local socket:|ChainDB:Notice:|:Critical:|Validating chunk)\b') 2>&1 &
     CARDANO_NODE_PID=$!
     MANAGED_CARDANO_NODE=true
 
@@ -211,7 +219,7 @@ fi
 ###############################################
 if [ ! -x "$(command -v ./tmp/ogmios/bin/ogmios)" ]; then
     echo 'OGMIOS NOT FOUND. INSTALLING OGMIOS...';
-    curl -sL https://github.com/CardanoSolutions/ogmios/releases/download/v${OGMIOS_VER}/ogmios-v${OGMIOS_VER}-x86_64-linux.zip -o ogmios.zip
+    curl -sL https://github.com/CardanoSolutions/ogmios/releases/download/v"${OGMIOS_VER}"/ogmios-v"${OGMIOS_VER}"-x86_64-linux.zip -o ogmios.zip
     unzip ogmios.zip -d ./tmp/ogmios && rm ogmios.zip && chmod +x ./tmp/ogmios/bin/ogmios
 fi
 
@@ -219,7 +227,7 @@ OGMIOS_PID="$(find_pid_by_arg "ogmios" "--node-socket ${SOCKET_PATH}")"
 if [[ -z "${OGMIOS_PID}" ]] || ! kill -0 "${OGMIOS_PID}" 2>/dev/null
 then
     echo "Starting Ogmios - connecting to ${SOCKET_PATH}"
-    ./tmp/ogmios/bin/ogmios $HOST $NODE_CONFIG $NODE_SOCKET $OGMIOS_PORT_ARG $@ --include-transaction-cbor --log-level Error &
+    ./tmp/ogmios/bin/ogmios "${OGMIOS_ARGS[@]}" --include-transaction-cbor --log-level Error &
     OGMIOS_PID=$!
     MANAGED_OGMIOS=true
 else


### PR DESCRIPTION
Fixes the CI root causes before preview-to-preprod promotion:

- use the committed npm lockfile on Node 22 instead of unlocked Yarn resolution on Node 18
- make unit/e2e environments explicit, including local logging, source Swagger, plaintext test Valkey on port 6380, and datum behavior
- test the actual exclusive 600-slot caught-up boundary
- preserve shell argument boundaries and resolve all ShellCheck findings

Validation:
- npm test: 69 suites / 724 tests passed
- npx tsc --noEmit
- shellcheck shell/*.sh
- bash -n shell/*.sh
- actionlint .github/workflows/*.yml
- git diff --check

No test wrote to Valkey port 6379.