### PR TITLE
Gate every release branch before merge

### DIFF
--- a/.github/workflows/docker-smoke-tests.yml
+++ b/.github/workflows/docker-smoke-tests.yml
@@ -21,7 +21,7 @@ on:
       - shell/test-container.sh
       - workers/**
   pull_request:
-    branches: [ preview ]
+    branches: [ preview, preprod, mainnet ]
     paths:
       - Dockerfile
       - package.json

--- a/.github/workflows/yarn-pr-tests.yml
+++ b/.github/workflows/yarn-pr-tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ preview, preprod, mainnet ]
   pull_request:
-    branches: [ preview ]
+    branches: [ preview, preprod, mainnet ]
 
 jobs:
   test:


### PR DESCRIPTION
Release-safety correction: both API test workflows already run after pushes to preview, preprod, and mainnet, but PR checks only targeted preview. This adds preprod/mainnet as PR bases so release reconciliation is tested before merge.

Validation: YAML/actionlint syntax check and git diff --check. The PR itself exercises the NPM gate; Docker smoke is path-filtered because runtime packaging is unchanged.